### PR TITLE
Add a test for encoding empty list

### DIFF
--- a/__tests__/coder/EthCoder.test.ts
+++ b/__tests__/coder/EthCoder.test.ts
@@ -34,6 +34,12 @@ describe('EthCoder', () => {
       )
     })
 
+    test('encode empty list', () => {
+      const list = List.from(Bytes, [])
+
+      EthCoder.encode(list)
+    })
+
     test('encode list of struct', () => {
       const factory = {
         default: () =>


### PR DESCRIPTION
I tried to apply Coder to `Property` and encode empty list in a test, then this exception happened.