### PR TITLE
Test RangeRecord.intersect(start, end)

### DIFF
--- a/__tests__/db/RangeRecord.test.ts
+++ b/__tests__/db/RangeRecord.test.ts
@@ -1,0 +1,51 @@
+import { RangeRecord } from '../../src/db/RangeStore'
+import { Bytes } from '../../src/types/Codables'
+
+describe('RangeRecord', () => {
+  const testValue = Bytes.fromString('value')
+  describe('intersect', () => {
+    // rangeRecord.start < testRange.start
+    it('does not intersect for [0-50) and [100-200)', () => {
+      const rangeRecord = new RangeRecord(0, 50, testValue)
+      expect(rangeRecord.intersect(100, 200)).toBeFalsy()
+    })
+    it('does not intersect for [0-100) and [100-200)', () => {
+      const rangeRecord = new RangeRecord(0, 100, testValue)
+      expect(rangeRecord.intersect(100, 200)).toBeFalsy()
+    })
+    it('intersects for [0-150) and [100-200)', () => {
+      const rangeRecord = new RangeRecord(0, 150, testValue)
+      expect(rangeRecord.intersect(100, 200)).toBeTruthy()
+    })
+    it('intersects for [0-200) and [100-200)', () => {
+      const rangeRecord = new RangeRecord(0, 200, testValue)
+      expect(rangeRecord.intersect(100, 200)).toBeTruthy()
+    })
+    it('intersect returns true when testRange[100, 200) is subrange of rangeRecord[0, 300)', () => {
+      const rangeRecord = new RangeRecord(0, 300, testValue)
+      expect(rangeRecord.intersect(100, 200)).toBeTruthy()
+    })
+    // rangeRecord.start == testRange.start
+    it('intersect returns true when rangeRecord and testRange are same ranges', () => {
+      const rangeRecord = new RangeRecord(0, 100, testValue)
+      expect(rangeRecord.intersect(0, 100)).toBeTruthy()
+    })
+    // rangeRecord.start > testRange.start
+    it('does not intersect for [100-200) and [0-50)', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(rangeRecord.intersect(0, 50)).toBeFalsy()
+    })
+    it('does not intersect for [100-200) and [0-100)', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(rangeRecord.intersect(0, 100)).toBeFalsy()
+    })
+    it('intersects for rangeRecord[100, 200) and testRange[0, 150)', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(rangeRecord.intersect(0, 150)).toBeTruthy()
+    })
+    it('intersects when rangeRecord[100, 200) is subrange of testRange[0, 300)', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(rangeRecord.intersect(0, 300)).toBeTruthy()
+    })
+  })
+})

--- a/__tests__/db/RangeRecord.test.ts
+++ b/__tests__/db/RangeRecord.test.ts
@@ -47,5 +47,24 @@ describe('RangeRecord', () => {
       const rangeRecord = new RangeRecord(100, 200, testValue)
       expect(rangeRecord.intersect(0, 300)).toBeTruthy()
     })
+    // other exceptions
+    it('throw error when start or end is negative value', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(() => {
+        rangeRecord.intersect(-100, 100)
+      }).toThrow('start must not be negative value.')
+      expect(() => {
+        rangeRecord.intersect(-200, -100)
+      }).toThrow('start must not be negative value.')
+    })
+    it('throw error when end is greater than start', () => {
+      const rangeRecord = new RangeRecord(100, 200, testValue)
+      expect(() => {
+        rangeRecord.intersect(500, 200)
+      }).toThrow('end must be greater than start.')
+      expect(() => {
+        rangeRecord.intersect(-200, -500)
+      }).toThrow('end must be greater than start.')
+    })
   })
 })

--- a/src/db/RangeStore.ts
+++ b/src/db/RangeStore.ts
@@ -23,6 +23,12 @@ export class RangeRecord {
     )
   }
   public intersect(start: number, end: number): boolean {
+    if (end <= start) {
+      throw new Error('end must be greater than start.')
+    }
+    if (start < 0) {
+      throw new Error('start must not be negative value.')
+    }
     const maxStart = Math.max(this.start, start)
     const maxEnd = Math.min(this.end, end)
     return maxStart < maxEnd


### PR DESCRIPTION
Adding test code for RangeRecord.intersect to clarify its spec. And making `intersect(start: number, end: number)` method throw exceptions when invalid `start` and `end` arguments are passed.