### PR TITLE
Issue/98/encode

### DIFF
--- a/__tests__/coder/Bytes.test.ts
+++ b/__tests__/coder/Bytes.test.ts
@@ -41,4 +41,16 @@ describe('Bytes', () => {
       expect(b1.equals(b2)).toBeFalsy()
     })
   })
+  describe('padZero', () => {
+    test('suceed to pad zeros', () => {
+      const b = Bytes.fromHexString('0x010203')
+      b.padZero(8)
+      expect(b.toHexString()).toBe('0x0000000000010203')
+    })
+    test('return false', () => {
+      const b1 = Bytes.fromHexString('0x010203')
+      const b2 = Bytes.fromHexString('0x010204')
+      expect(b1.equals(b2)).toBeFalsy()
+    })
+  })
 })

--- a/__tests__/verifiers/tree/AddressTree.test.ts
+++ b/__tests__/verifiers/tree/AddressTree.test.ts
@@ -39,12 +39,40 @@ describe('AddressTree', () => {
       const tree = new AddressTree([leaf0, leaf1, leaf2, leaf3])
       const inclusionProof0 = tree.getInclusionProof(0)
       const inclusionProof1 = tree.getInclusionProof(1)
-      expect(inclusionProof0.toHexString()).toStrictEqual(
-        '0x0000000099fff0297ffbd7e2f1a6820971ba8fa9d502e2a9259ff15813849b63e09af0c10000000000000000000000000000000000000001350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca30000000000000000000000000000000000000002'
-      )
-      expect(inclusionProof1.toHexString()).toStrictEqual(
-        '0x01000000cca51deaf7e2f905f605c563fc14ce3f5314136d90598cf77da785cf016f6a3f0000000000000000000000000000000000000000350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca30000000000000000000000000000000000000002'
-      )
+      expect(inclusionProof0).toStrictEqual({
+        leafPosition: 0,
+        siblings: [
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000001'),
+            Bytes.fromHexString(
+              '0x99fff0297ffbd7e2f1a6820971ba8fa9d502e2a9259ff15813849b63e09af0c1'
+            )
+          ),
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000002'),
+            Bytes.fromHexString(
+              '0x350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca3'
+            )
+          )
+        ]
+      })
+      expect(inclusionProof1).toStrictEqual({
+        leafPosition: 1,
+        siblings: [
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000000'),
+            Bytes.fromHexString(
+              '0xcca51deaf7e2f905f605c563fc14ce3f5314136d90598cf77da785cf016f6a3f'
+            )
+          ),
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000002'),
+            Bytes.fromHexString(
+              '0x350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca3'
+            )
+          )
+        ]
+      })
     })
   })
   describe('verifyInclusion', () => {
@@ -53,9 +81,23 @@ describe('AddressTree', () => {
       const root = Bytes.fromHexString(
         '0x30acf9f99796b1b310d05d35854812ff91f43cb3f35c932c0d8053bbae3a661e'
       )
-      const inclusionProof = Bytes.fromHexString(
-        '0x0000000099fff0297ffbd7e2f1a6820971ba8fa9d502e2a9259ff15813849b63e09af0c10000000000000000000000000000000000000001350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca30000000000000000000000000000000000000002'
-      )
+      const inclusionProof = {
+        leafPosition: 0,
+        siblings: [
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000001'),
+            Bytes.fromHexString(
+              '0x99fff0297ffbd7e2f1a6820971ba8fa9d502e2a9259ff15813849b63e09af0c1'
+            )
+          ),
+          new AddressTreeNode(
+            Address.from('0x0000000000000000000000000000000000000002'),
+            Bytes.fromHexString(
+              '0x350008941a274700780a1247fa6e7b2db5c34f1bfbcf15e9fb9230f6dd239ca3'
+            )
+          )
+        ]
+      }
       const result = tree.verifyInclusion(leaf0, root, inclusionProof)
       expect(result).toBeTruthy()
     })

--- a/__tests__/verifiers/tree/DoubleLayerTree.test.ts
+++ b/__tests__/verifiers/tree/DoubleLayerTree.test.ts
@@ -8,7 +8,7 @@ import {
   AddressTreeNode,
   IntervalTreeNode
 } from '../../../src/verifiers/tree'
-import { Bytes, Integer, Address } from '../../../src/types'
+import { Bytes, BigNumber, Address } from '../../../src/types'
 import { Keccak256 } from '../../../src/verifiers/hash/Keccak256'
 
 describe('DoubleLayerTree', () => {
@@ -27,32 +27,32 @@ describe('DoubleLayerTree', () => {
     const token1 = Address.from('0x0000000000000000000000000000000000000001')
     const leaf0 = new DoubleLayerTreeLeaf(
       token0,
-      Integer.from(0),
+      BigNumber.from(0n),
       Keccak256.hash(Bytes.fromString('leaf0'))
     )
     const leaf1 = new DoubleLayerTreeLeaf(
       token0,
-      Integer.from(7),
+      BigNumber.from(7n),
       Keccak256.hash(Bytes.fromString('leaf1'))
     )
     const leaf2 = new DoubleLayerTreeLeaf(
       token0,
-      Integer.from(15),
+      BigNumber.from(15n),
       Keccak256.hash(Bytes.fromString('leaf2'))
     )
     const leaf3 = new DoubleLayerTreeLeaf(
       token0,
-      Integer.from(5000),
+      BigNumber.from(5000n),
       Keccak256.hash(Bytes.fromString('leaf3'))
     )
     const leaf10 = new DoubleLayerTreeLeaf(
       token1,
-      Integer.from(100),
+      BigNumber.from(100n),
       Keccak256.hash(Bytes.fromString('token1leaf0'))
     )
     const leaf11 = new DoubleLayerTreeLeaf(
       token1,
-      Integer.from(200),
+      BigNumber.from(200n),
       Keccak256.hash(Bytes.fromString('token1leaf1'))
     )
     beforeEach(() => {})
@@ -60,7 +60,7 @@ describe('DoubleLayerTree', () => {
       it('throw exception invalid data length', async () => {
         const invalidLeaf = new DoubleLayerTreeLeaf(
           token0,
-          Integer.from(500),
+          BigNumber.from(500n),
           Bytes.fromString('leaf0')
         )
         expect(() => {
@@ -71,7 +71,7 @@ describe('DoubleLayerTree', () => {
         const tree = new DoubleLayerTree([leaf0, leaf1, leaf2])
         const root = tree.getRoot()
         expect(root.toHexString()).toStrictEqual(
-          '0x4a49d1b90d42046cfbf2169ba520f7633d793645876370ac0acdb85f3fbcade6'
+          '0xb3c02deef1a1beeaa2899ac0fbeca57a13aa36dff9742c974113f2ceef7f7278'
         )
       })
       it('return Merkle Root with leaves that belongs to multiple address', async () => {
@@ -85,7 +85,7 @@ describe('DoubleLayerTree', () => {
         ])
         const root = tree.getRoot()
         expect(root.toHexString()).toStrictEqual(
-          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
+          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
         )
       })
     })
@@ -112,21 +112,21 @@ describe('DoubleLayerTree', () => {
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x3976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c3'
+                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
               )
             )
           ]),
           intervalInclusionProof: new IntervalTreeInclusionProof(0, [
             new IntervalTreeNode(
-              Integer.from(7),
+              BigNumber.from(7n),
               Bytes.fromHexString(
                 '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
               )
             ),
             new IntervalTreeNode(
-              Integer.from(5000),
+              BigNumber.from(5000n),
               Bytes.fromHexString(
-                '0xe2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c42'
+                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
               )
             )
           ])
@@ -136,21 +136,21 @@ describe('DoubleLayerTree', () => {
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x3976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c3'
+                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
               )
             )
           ]),
           intervalInclusionProof: new IntervalTreeInclusionProof(1, [
             new IntervalTreeNode(
-              Integer.from(0),
+              BigNumber.from(0n),
               Bytes.fromHexString(
                 '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
               )
             ),
             new IntervalTreeNode(
-              Integer.from(5000),
+              BigNumber.from(5000n),
               Bytes.fromHexString(
-                '0xe2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c42'
+                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
               )
             )
           ])
@@ -164,21 +164,21 @@ describe('DoubleLayerTree', () => {
           new AddressTreeNode(
             Address.from('0x0000000000000000000000000000000000000001'),
             Bytes.fromHexString(
-              '0x3976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c3'
+              '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
             )
           )
         ]),
         intervalInclusionProof: new IntervalTreeInclusionProof(0, [
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
               '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(5000),
+            BigNumber.from(5000n),
             Bytes.fromHexString(
-              '0xe2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c42'
+              '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
             )
           )
         ])
@@ -186,7 +186,7 @@ describe('DoubleLayerTree', () => {
       it('return true', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
+          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
         )
         const result = verifier.verifyInclusion(
           leaf0,
@@ -198,7 +198,7 @@ describe('DoubleLayerTree', () => {
       it('return false with invalid proof', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
+          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
         )
         const result = verifier.verifyInclusion(
           leaf1,
@@ -210,28 +210,28 @@ describe('DoubleLayerTree', () => {
       it('throw exception detecting intersection', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
+          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
         )
         const invalidInclusionProof = {
           addressInclusionProof: new AddressTreeInclusionProof(0, [
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x3976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c3'
+                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
               )
             )
           ]),
           intervalInclusionProof: new IntervalTreeInclusionProof(0, [
             new IntervalTreeNode(
-              Integer.from(7),
+              BigNumber.from(7n),
               Bytes.fromHexString(
                 '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
               )
             ),
             new IntervalTreeNode(
-              Integer.from(0),
+              BigNumber.from(0n),
               Bytes.fromHexString(
-                '0xe2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c42'
+                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
               )
             )
           ])
@@ -243,28 +243,28 @@ describe('DoubleLayerTree', () => {
       it('throw exception left.start is not less than right.start', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
+          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
         )
         const invalidInclusionProof = {
           addressInclusionProof: new AddressTreeInclusionProof(0, [
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x3976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c3'
+                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
               )
             )
           ]),
           intervalInclusionProof: new IntervalTreeInclusionProof(1, [
             new IntervalTreeNode(
-              Integer.from(0),
+              BigNumber.from(0n),
               Bytes.fromHexString(
                 '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
               )
             ),
             new IntervalTreeNode(
-              Integer.from(0),
+              BigNumber.from(0n),
               Bytes.fromHexString(
-                '0xe2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c42'
+                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
               )
             )
           ])
@@ -278,12 +278,12 @@ describe('DoubleLayerTree', () => {
     describe('getLeaves', () => {
       it('return leaves', async () => {
         const tree = new DoubleLayerTree([leaf0, leaf1, leaf2, leaf3])
-        const leaves = tree.getLeaves(token0, 0, 100)
+        const leaves = tree.getLeaves(token0, BigInt(0), BigInt(100))
         expect(leaves.length).toStrictEqual(3)
       })
       it('return leaves within partially', async () => {
         const tree = new DoubleLayerTree([leaf0, leaf1, leaf2, leaf3])
-        const leaves = tree.getLeaves(token0, 5, 100)
+        const leaves = tree.getLeaves(token0, BigInt(5), BigInt(100))
         expect(leaves.length).toStrictEqual(3)
       })
     })

--- a/__tests__/verifiers/tree/DoubleLayerTree.test.ts
+++ b/__tests__/verifiers/tree/DoubleLayerTree.test.ts
@@ -115,10 +115,10 @@ describe('DoubleLayerTree', () => {
       it('return true', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x22a1b078fc6e327f3aeb1ce67f7bb8e79842af7d71b0010ae399dccedcbea9d3'
+          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
         )
         const inclusionProof = Bytes.fromHexString(
-          '0x4c00000000000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c428813000000000000'
+          '0x4c00000000000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c4288130000000000003976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c30000000000000000000000000000000000000001'
         )
         const result = verifier.verifyInclusion(leaf0, root, inclusionProof)
         expect(result).toBeTruthy()
@@ -126,10 +126,10 @@ describe('DoubleLayerTree', () => {
       it('return false with invalid proof', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x22a1b078fc6e327f3aeb1ce67f7bb8e79842af7d71b0010ae399dccedcbea9d3'
+          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
         )
         const inclusionProof = Bytes.fromHexString(
-          '0x4c00000000000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c428813000000000000'
+          '0x4c00000000000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c4288130000000000003976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c30000000000000000000000000000000000000001'
         )
         const result = verifier.verifyInclusion(leaf1, root, inclusionProof)
         expect(result).toBeFalsy()
@@ -137,7 +137,7 @@ describe('DoubleLayerTree', () => {
       it('throw exception detecting intersection', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x22a1b078fc6e327f3aeb1ce67f7bb8e79842af7d71b0010ae399dccedcbea9d3'
+          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
         )
         const invalidInclusionProof = Bytes.fromHexString(
           '0x4c00000000000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c4200000000000000003976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c30000000000000000000000000000000000000001'
@@ -149,7 +149,7 @@ describe('DoubleLayerTree', () => {
       it('throw exception left.start is not less than right.start', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x22a1b078fc6e327f3aeb1ce67f7bb8e79842af7d71b0010ae399dccedcbea9d3'
+          '0xa34d4463f99ddbe6ffb3448cb791d1ce820bdf24040fccd49ce0b263910ab56e'
         )
         const invalidInclusionProof = Bytes.fromHexString(
           '0x4c000000010000006fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a3000000000e2c6d421a374d1a99d7f7a0edab00248456de98c4481a3bc50b69d7078be1c4200000000000000003976203688d2e19df2eeb8f1b6dd81dc84b9c69fa9bab08e133d9633859eb2c30000000000000000000000000000000000000001'

--- a/__tests__/verifiers/tree/DoubleLayerTree.test.ts
+++ b/__tests__/verifiers/tree/DoubleLayerTree.test.ts
@@ -71,7 +71,7 @@ describe('DoubleLayerTree', () => {
         const tree = new DoubleLayerTree([leaf0, leaf1, leaf2])
         const root = tree.getRoot()
         expect(root.toHexString()).toStrictEqual(
-          '0xb3c02deef1a1beeaa2899ac0fbeca57a13aa36dff9742c974113f2ceef7f7278'
+          '0x3ec5a3c49278e6d89a313d2f8716b1cf62534f3c31fdcade30809fd90ee47368'
         )
       })
       it('return Merkle Root with leaves that belongs to multiple address', async () => {
@@ -85,7 +85,7 @@ describe('DoubleLayerTree', () => {
         ])
         const root = tree.getRoot()
         expect(root.toHexString()).toStrictEqual(
-          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
+          '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
       })
     })
@@ -107,12 +107,18 @@ describe('DoubleLayerTree', () => {
           token0,
           1
         )
+        console.log(
+          inclusionProof0.intervalInclusionProof.siblings[1].data.toHexString()
+        )
+        console.log(
+          inclusionProof1.intervalInclusionProof.siblings[1].data.toHexString()
+        )
         expect(inclusionProof0).toEqual({
           addressInclusionProof: new AddressTreeInclusionProof(0, [
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
+                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
               )
             )
           ]),
@@ -126,7 +132,7 @@ describe('DoubleLayerTree', () => {
             new IntervalTreeNode(
               BigNumber.from(5000n),
               Bytes.fromHexString(
-                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
               )
             )
           ])
@@ -136,7 +142,7 @@ describe('DoubleLayerTree', () => {
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
+                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
               )
             )
           ]),
@@ -150,7 +156,7 @@ describe('DoubleLayerTree', () => {
             new IntervalTreeNode(
               BigNumber.from(5000n),
               Bytes.fromHexString(
-                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
               )
             )
           ])
@@ -164,7 +170,7 @@ describe('DoubleLayerTree', () => {
           new AddressTreeNode(
             Address.from('0x0000000000000000000000000000000000000001'),
             Bytes.fromHexString(
-              '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
+              '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
             )
           )
         ]),
@@ -178,7 +184,7 @@ describe('DoubleLayerTree', () => {
           new IntervalTreeNode(
             BigNumber.from(5000n),
             Bytes.fromHexString(
-              '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
+              '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
             )
           )
         ])
@@ -186,7 +192,7 @@ describe('DoubleLayerTree', () => {
       it('return true', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
+          '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const result = verifier.verifyInclusion(
           leaf0,
@@ -198,7 +204,7 @@ describe('DoubleLayerTree', () => {
       it('return false with invalid proof', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
+          '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const result = verifier.verifyInclusion(
           leaf1,
@@ -210,14 +216,14 @@ describe('DoubleLayerTree', () => {
       it('throw exception detecting intersection', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
+          '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const invalidInclusionProof = {
           addressInclusionProof: new AddressTreeInclusionProof(0, [
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
+                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
               )
             )
           ]),
@@ -231,7 +237,7 @@ describe('DoubleLayerTree', () => {
             new IntervalTreeNode(
               BigNumber.from(0n),
               Bytes.fromHexString(
-                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
               )
             )
           ])
@@ -243,14 +249,14 @@ describe('DoubleLayerTree', () => {
       it('throw exception left.start is not less than right.start', async () => {
         const verifier = new DoubleLayerTreeVerifier()
         const root = Bytes.fromHexString(
-          '0x035a06175d142ae49863b8a36ed96ab1501a2246d788d3bce130fbca6d6fb533'
+          '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const invalidInclusionProof = {
           addressInclusionProof: new AddressTreeInclusionProof(0, [
             new AddressTreeNode(
               Address.from('0x0000000000000000000000000000000000000001'),
               Bytes.fromHexString(
-                '0x5f57670cfe1f6a20e334282a42a5a340056876b4990beeaae749808323202803'
+                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
               )
             )
           ]),
@@ -264,7 +270,7 @@ describe('DoubleLayerTree', () => {
             new IntervalTreeNode(
               BigNumber.from(0n),
               Bytes.fromHexString(
-                '0x5c9325f01140a171a76dd4ac2111bfe6d404f7fd8fdee094ecfb0164a9c7315b'
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
               )
             )
           ])

--- a/__tests__/verifiers/tree/IntervalTree.test.ts
+++ b/__tests__/verifiers/tree/IntervalTree.test.ts
@@ -4,27 +4,27 @@ import {
   IntervalTreeVerifier
 } from '../../../src/verifiers/tree'
 import { Keccak256 } from '../../../src/verifiers/hash/Keccak256'
-import { Bytes, Integer } from '../../../src/types'
+import { Bytes, BigNumber } from '../../../src/types'
 
 describe('IntervalTree', () => {
   const leaf0 = new IntervalTreeNode(
-    Integer.from(0),
+    BigNumber.from(BigInt(0)),
     Keccak256.hash(Bytes.fromString('leaf0'))
   )
   const leaf1 = new IntervalTreeNode(
-    Integer.from(7),
+    BigNumber.from(7n),
     Keccak256.hash(Bytes.fromString('leaf1'))
   )
   const leaf2 = new IntervalTreeNode(
-    Integer.from(15),
+    BigNumber.from(15n),
     Keccak256.hash(Bytes.fromString('leaf2'))
   )
   const leaf3 = new IntervalTreeNode(
-    Integer.from(300),
+    BigNumber.from(300n),
     Keccak256.hash(Bytes.fromString('leaf3'))
   )
   const leafBigNumber = new IntervalTreeNode(
-    Integer.from(72943610),
+    BigNumber.from(72943610n),
     Keccak256.hash(Bytes.fromString('leaf4'))
   )
   beforeEach(() => {})
@@ -33,21 +33,21 @@ describe('IntervalTree', () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0x4a49d1b90d42046cfbf2169ba520f7633d793645876370ac0acdb85f3fbcade6'
+        '0xb3c02deef1a1beeaa2899ac0fbeca57a13aa36dff9742c974113f2ceef7f7278'
       )
     })
     it('return Merkle Root with even number of leaves', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leaf3])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0x4117eee42ff1ddefc65223c1560b411da17da6a6afed5ea4796ca952cfa95587'
+        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
       )
     })
     it('return Merkle Root with leaf which has big number as start', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leaf3, leafBigNumber])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0x5fcc7e390d4144644a7299e5778fbf2e4aae70bbb0fe03a84e94267151e28017'
+        '0x32ceeebf21cc9f9562929b7c84ab64224fc73bc4042e06740d6492145b0cb9a5'
       )
     })
   })
@@ -60,15 +60,15 @@ describe('IntervalTree', () => {
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
               '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(0xffffffff),
+            BigNumber.MAX_NUMBER,
             Bytes.fromHexString(
-              '0xe773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30'
+              '0x70292008554cf98a985dae6b98f9a3a3247f40b02c7b0e210f49fd4d1925b010'
             )
           )
         ]
@@ -77,15 +77,15 @@ describe('IntervalTree', () => {
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(0),
+            BigNumber.from(0n),
             Bytes.fromHexString(
               '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(0xffffffff),
+            BigNumber.MAX_NUMBER,
             Bytes.fromHexString(
-              '0xe773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30'
+              '0x70292008554cf98a985dae6b98f9a3a3247f40b02c7b0e210f49fd4d1925b010'
             )
           )
         ]
@@ -101,15 +101,15 @@ describe('IntervalTree', () => {
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
               '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(300),
+            BigNumber.from(300n),
             Bytes.fromHexString(
-              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
             )
           )
         ]
@@ -118,15 +118,15 @@ describe('IntervalTree', () => {
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(0),
+            BigNumber.from(0n),
             Bytes.fromHexString(
               '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(300),
+            BigNumber.from(300n),
             Bytes.fromHexString(
-              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
             )
           )
         ]
@@ -135,15 +135,15 @@ describe('IntervalTree', () => {
         leafPosition: 2,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(300),
+            BigNumber.from(300n),
             Bytes.fromHexString(
               '0xfdd1f2a1ec75fe968421a41d2282200de6bec6a21f81080a71b1053d9c0120f3'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
-              '0x332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a'
+              '0xd62f20cef4c9739c04c2302624e272673b3655b450f1e6afbe8a28bab1d78f95'
             )
           )
         ]
@@ -152,15 +152,15 @@ describe('IntervalTree', () => {
         leafPosition: 3,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(15),
+            BigNumber.from(15n),
             Bytes.fromHexString(
-              'ba620d61dac4ddf2d7905722b259b0bd34ec4d37c5796d9a22537c54b3f972d8'
+              '0xba620d61dac4ddf2d7905722b259b0bd34ec4d37c5796d9a22537c54b3f972d8'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
-              '332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a'
+              '0xd62f20cef4c9739c04c2302624e272673b3655b450f1e6afbe8a28bab1d78f95'
             )
           )
         ]
@@ -205,21 +205,21 @@ describe('IntervalTree', () => {
     })
     it('throw exception detecting intersection', () => {
       const root = Bytes.fromHexString(
-        '0x4117eee42ff1ddefc65223c1560b411da17da6a6afed5ea4796ca952cfa95587'
+        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
       )
       const invalidInclusionProof = {
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(7),
+            BigNumber.from(7n),
             Bytes.fromHexString(
               '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(0x00000000),
+            BigNumber.from(0n),
             Bytes.fromHexString(
-              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
             )
           )
         ]
@@ -230,21 +230,21 @@ describe('IntervalTree', () => {
     })
     it('throw exception left.start is not less than right.start', () => {
       const root = Bytes.fromHexString(
-        '0x4117eee42ff1ddefc65223c1560b411da17da6a6afed5ea4796ca952cfa95587'
+        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
       )
       const invalidInclusionProof = {
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
-            Integer.from(0),
+            BigNumber.from(0n),
             Bytes.fromHexString(
-              '6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+              '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
             )
           ),
           new IntervalTreeNode(
-            Integer.from(0),
+            BigNumber.from(0n),
             Bytes.fromHexString(
-              'c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
             )
           )
         ]
@@ -257,12 +257,12 @@ describe('IntervalTree', () => {
   describe('getLeaves', () => {
     it('return leaves', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
-      const leaves = tree.getLeaves(0, 100)
+      const leaves = tree.getLeaves(0n, 100n)
       expect(leaves.length).toStrictEqual(3)
     })
     it('return leaves within partially', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
-      const leaves = tree.getLeaves(5, 100)
+      const leaves = tree.getLeaves(5n, 100n)
       expect(leaves.length).toStrictEqual(3)
     })
   })

--- a/__tests__/verifiers/tree/IntervalTree.test.ts
+++ b/__tests__/verifiers/tree/IntervalTree.test.ts
@@ -33,21 +33,21 @@ describe('IntervalTree', () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0xb3c02deef1a1beeaa2899ac0fbeca57a13aa36dff9742c974113f2ceef7f7278'
+        '0x3ec5a3c49278e6d89a313d2f8716b1cf62534f3c31fdcade30809fd90ee47368'
       )
     })
     it('return Merkle Root with even number of leaves', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leaf3])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
+        '0x91d07b5d34a03ce1831ff23c6528d2cbf64adc24e3321373dc616a6740b02577'
       )
     })
     it('return Merkle Root with leaf which has big number as start', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leaf3, leafBigNumber])
       const root = tree.getRoot()
       expect(root.toHexString()).toStrictEqual(
-        '0x32ceeebf21cc9f9562929b7c84ab64224fc73bc4042e06740d6492145b0cb9a5'
+        '0xc6cc7cbcdbb1c6eeb1d42e4866dc8319645bb1081a6c93ceb54eb11eb4be3f1c'
       )
     })
   })
@@ -68,7 +68,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.MAX_NUMBER,
             Bytes.fromHexString(
-              '0x70292008554cf98a985dae6b98f9a3a3247f40b02c7b0e210f49fd4d1925b010'
+              '0xe99f92621ea9ca2e0709f58dc56c139ecf076c388952df2b5cd7a6ca1ae2df5c'
             )
           )
         ]
@@ -85,7 +85,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.MAX_NUMBER,
             Bytes.fromHexString(
-              '0x70292008554cf98a985dae6b98f9a3a3247f40b02c7b0e210f49fd4d1925b010'
+              '0xe99f92621ea9ca2e0709f58dc56c139ecf076c388952df2b5cd7a6ca1ae2df5c'
             )
           )
         ]
@@ -109,7 +109,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(300n),
             Bytes.fromHexString(
-              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
+              '0x4670e484ff31d2ec8471b1f8a1e1cb8dc104b3a4b766ae0b7c2c604a34cb530e'
             )
           )
         ]
@@ -126,7 +126,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(300n),
             Bytes.fromHexString(
-              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
+              '0x4670e484ff31d2ec8471b1f8a1e1cb8dc104b3a4b766ae0b7c2c604a34cb530e'
             )
           )
         ]
@@ -143,7 +143,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(7n),
             Bytes.fromHexString(
-              '0xd62f20cef4c9739c04c2302624e272673b3655b450f1e6afbe8a28bab1d78f95'
+              '0x59a76952828fd54de12b708bf0030e055ae148c0a5a7d8b4f191d519275337e8'
             )
           )
         ]
@@ -160,7 +160,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(7n),
             Bytes.fromHexString(
-              '0xd62f20cef4c9739c04c2302624e272673b3655b450f1e6afbe8a28bab1d78f95'
+              '0x59a76952828fd54de12b708bf0030e055ae148c0a5a7d8b4f191d519275337e8'
             )
           )
         ]
@@ -205,7 +205,7 @@ describe('IntervalTree', () => {
     })
     it('throw exception detecting intersection', () => {
       const root = Bytes.fromHexString(
-        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
+        '0x91d07b5d34a03ce1831ff23c6528d2cbf64adc24e3321373dc616a6740b02577'
       )
       const invalidInclusionProof = {
         leafPosition: 0,
@@ -219,7 +219,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(0n),
             Bytes.fromHexString(
-              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
+              '0x4670e484ff31d2ec8471b1f8a1e1cb8dc104b3a4b766ae0b7c2c604a34cb530e'
             )
           )
         ]
@@ -230,7 +230,7 @@ describe('IntervalTree', () => {
     })
     it('throw exception left.start is not less than right.start', () => {
       const root = Bytes.fromHexString(
-        '0x295438ca451d0bfcb2ae28086c9a7d79bdf94736eac89b9e44a1af3f257fcb5d'
+        '0x91d07b5d34a03ce1831ff23c6528d2cbf64adc24e3321373dc616a6740b02577'
       )
       const invalidInclusionProof = {
         leafPosition: 1,
@@ -244,7 +244,7 @@ describe('IntervalTree', () => {
           new IntervalTreeNode(
             BigNumber.from(0n),
             Bytes.fromHexString(
-              '0xbb3c3d12ce9cc6b2de4be3085a5d82baedb44b622ab80853020104e03b9fa34e'
+              '0x4670e484ff31d2ec8471b1f8a1e1cb8dc104b3a4b766ae0b7c2c604a34cb530e'
             )
           )
         ]

--- a/__tests__/verifiers/tree/IntervalTree.test.ts
+++ b/__tests__/verifiers/tree/IntervalTree.test.ts
@@ -56,12 +56,40 @@ describe('IntervalTree', () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
       const inclusionProof0 = tree.getInclusionProof(0)
       const inclusionProof1 = tree.getInclusionProof(1)
-      expect(inclusionProof0.toHexString()).toStrictEqual(
-        '0x00000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000e773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30ffffffff'
-      )
-      expect(inclusionProof1.toHexString()).toStrictEqual(
-        '0x010000006fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a3000000000e773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30ffffffff'
-      )
+      expect(inclusionProof0).toStrictEqual({
+        leafPosition: 0,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(7),
+            Bytes.fromHexString(
+              '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(0xffffffff),
+            Bytes.fromHexString(
+              '0xe773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30'
+            )
+          )
+        ]
+      })
+      expect(inclusionProof1).toStrictEqual({
+        leafPosition: 1,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(0),
+            Bytes.fromHexString(
+              '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(0xffffffff),
+            Bytes.fromHexString(
+              '0xe773031f8fe828e549ae4da698004d32bb7f3510a8ca3794010f1fe5b0637b30'
+            )
+          )
+        ]
+      })
     })
     it('return InclusionProof with even number of leaves', async () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leaf3])
@@ -69,18 +97,74 @@ describe('IntervalTree', () => {
       const inclusionProof1 = tree.getInclusionProof(1)
       const inclusionProof2 = tree.getInclusionProof(2)
       const inclusionProof3 = tree.getInclusionProof(3)
-      expect(inclusionProof0.toHexString()).toStrictEqual(
-        '0x00000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a2c010000'
-      )
-      expect(inclusionProof1.toHexString()).toStrictEqual(
-        '0x010000006fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a3000000000c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a2c010000'
-      )
-      expect(inclusionProof2.toHexString()).toStrictEqual(
-        '0x02000000fdd1f2a1ec75fe968421a41d2282200de6bec6a21f81080a71b1053d9c0120f32c010000332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a07000000'
-      )
-      expect(inclusionProof3.toHexString()).toStrictEqual(
-        '0x03000000ba620d61dac4ddf2d7905722b259b0bd34ec4d37c5796d9a22537c54b3f972d80f000000332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a07000000'
-      )
+      expect(inclusionProof0).toStrictEqual({
+        leafPosition: 0,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(7),
+            Bytes.fromHexString(
+              '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(300),
+            Bytes.fromHexString(
+              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+            )
+          )
+        ]
+      })
+      expect(inclusionProof1).toStrictEqual({
+        leafPosition: 1,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(0),
+            Bytes.fromHexString(
+              '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(300),
+            Bytes.fromHexString(
+              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+            )
+          )
+        ]
+      })
+      expect(inclusionProof2).toStrictEqual({
+        leafPosition: 2,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(300),
+            Bytes.fromHexString(
+              '0xfdd1f2a1ec75fe968421a41d2282200de6bec6a21f81080a71b1053d9c0120f3'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(7),
+            Bytes.fromHexString(
+              '0x332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a'
+            )
+          )
+        ]
+      })
+      expect(inclusionProof3).toStrictEqual({
+        leafPosition: 3,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(15),
+            Bytes.fromHexString(
+              'ba620d61dac4ddf2d7905722b259b0bd34ec4d37c5796d9a22537c54b3f972d8'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(7),
+            Bytes.fromHexString(
+              '332102f598c3de984496b1e7c77d0e4c858a2e0e063ed2e1c63331e85c38173a'
+            )
+          )
+        ]
+      })
     })
   })
   describe('verifyInclusion', () => {
@@ -123,9 +207,23 @@ describe('IntervalTree', () => {
       const root = Bytes.fromHexString(
         '0x4117eee42ff1ddefc65223c1560b411da17da6a6afed5ea4796ca952cfa95587'
       )
-      const invalidInclusionProof = Bytes.fromHexString(
-        '0x00000000036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da07000000c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a00000000'
-      )
+      const invalidInclusionProof = {
+        leafPosition: 0,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(7),
+            Bytes.fromHexString(
+              '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(0x00000000),
+            Bytes.fromHexString(
+              '0xc09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+            )
+          )
+        ]
+      }
       expect(() => {
         verifier.verifyInclusion(leaf0, root, invalidInclusionProof)
       }).toThrow(new Error('Invalid InclusionProof, intersection detected.'))
@@ -134,9 +232,23 @@ describe('IntervalTree', () => {
       const root = Bytes.fromHexString(
         '0x4117eee42ff1ddefc65223c1560b411da17da6a6afed5ea4796ca952cfa95587'
       )
-      const invalidInclusionProof = Bytes.fromHexString(
-        '0x010000006fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a3000000000c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a00000000'
-      )
+      const invalidInclusionProof = {
+        leafPosition: 1,
+        siblings: [
+          new IntervalTreeNode(
+            Integer.from(0),
+            Bytes.fromHexString(
+              '6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+            )
+          ),
+          new IntervalTreeNode(
+            Integer.from(0),
+            Bytes.fromHexString(
+              'c09681b30efdae69430f6661b21f80c49a6864061578412256a53e92cefc253a'
+            )
+          )
+        ]
+      }
       expect(() => {
         verifier.verifyInclusion(leaf1, root, invalidInclusionProof)
       }).toThrow(new Error('left.start is not less than right.start.'))

--- a/src/types/Codables/Bytes.ts
+++ b/src/types/Codables/Bytes.ts
@@ -62,6 +62,14 @@ export default class Bytes implements Codable {
     )
   }
 
+  public padZero(length: number): Bytes {
+    const buffer = new ArrayBuffer(length)
+    const newData = new Uint8Array(buffer)
+    newData.set(this.data, length - this.data.length)
+    this.data = newData
+    return this
+  }
+
   public equals(target: Bytes): boolean {
     return Buffer.compare(Buffer.from(this.data), Buffer.from(target.data)) == 0
   }

--- a/src/verifiers/tree/AddressTree.ts
+++ b/src/verifiers/tree/AddressTree.ts
@@ -3,7 +3,15 @@ import {
   AbstractMerkleTree,
   AbstractMerkleVerifier
 } from './AbstractMerkleTree'
-import { MerkleTreeNode } from './MerkleTreeInterface'
+import { MerkleTreeNode, InclusionProof } from './MerkleTreeInterface'
+
+export class AddressTreeInclusionProof
+  implements InclusionProof<AddressTreeNode> {
+  constructor(
+    public leafPosition: number,
+    public siblings: AddressTreeNode[]
+  ) {}
+}
 
 export class AddressTreeNode implements MerkleTreeNode {
   constructor(public address: Address, public data: Bytes) {
@@ -14,7 +22,10 @@ export class AddressTreeNode implements MerkleTreeNode {
   }
 }
 
-export class AddressTree extends AbstractMerkleTree<AddressTreeNode> {
+export class AddressTree extends AbstractMerkleTree<
+  AddressTreeNode,
+  AddressTreeInclusionProof
+> {
   constructor(leaves: AddressTreeNode[]) {
     super(leaves, new AddressTreeVerifier())
   }
@@ -25,7 +36,8 @@ export class AddressTree extends AbstractMerkleTree<AddressTreeNode> {
 }
 
 export class AddressTreeVerifier extends AbstractMerkleVerifier<
-  AddressTreeNode
+  AddressTreeNode,
+  AddressTreeInclusionProof
 > {
   computeRootFromInclusionProof(
     leaf: AddressTreeNode,
@@ -48,24 +60,6 @@ export class AddressTreeVerifier extends AbstractMerkleVerifier<
       computed = this.computeParent(left, right)
     }
     return computed.data
-  }
-
-  decodeProofElements(bytes: Bytes): AddressTreeNode[] {
-    const buf = Buffer.from(bytes.data)
-    const nodes: AddressTreeNode[] = []
-    for (let i = 0; i < buf.length; i += 52) {
-      nodes.push(
-        new AddressTreeNode(
-          Address.from(
-            Bytes.from(
-              Uint8Array.from(buf.subarray(i + 32, i + 52))
-            ).toHexString()
-          ),
-          Bytes.from(Uint8Array.from(buf.subarray(i, i + 32)))
-        )
-      )
-    }
-    return nodes
   }
 
   computeParent(a: AddressTreeNode, b: AddressTreeNode): AddressTreeNode {

--- a/src/verifiers/tree/DoubleLayerTree.ts
+++ b/src/verifiers/tree/DoubleLayerTree.ts
@@ -1,4 +1,4 @@
-import { Bytes, Address, Integer, Struct } from '../../types'
+import { Bytes, Address, BigNumber } from '../../types'
 import {
   MerkleTreeInterface,
   MerkleTreeGenerator,
@@ -26,7 +26,7 @@ export interface DoubleLayerInclusionProof {
 export class DoubleLayerTreeLeaf implements MerkleTreeNode {
   constructor(
     public address: Address,
-    public start: Integer,
+    public start: BigNumber,
     public data: Bytes
   ) {}
   encode(): Bytes {
@@ -94,7 +94,7 @@ export class DoubleLayerTree
   getLeaf(index: number): DoubleLayerTreeLeaf {
     throw new Error('not implemented')
   }
-  getLeaves(address: Address, start: number, end: number): number[] {
+  getLeaves(address: Address, start: bigint, end: bigint): number[] {
     const tree = this.intervalTreeMap.get(address.data)
     if (tree) {
       return tree.getLeaves(start, end)

--- a/src/verifiers/tree/IntervalTree.ts
+++ b/src/verifiers/tree/IntervalTree.ts
@@ -26,7 +26,7 @@ export class IntervalTreeNode implements MerkleTreeNode {
   encode(): Bytes {
     return Bytes.concat([
       this.data,
-      Bytes.fromHexString(this.start.data.toString(16))
+      Bytes.fromHexString(this.start.data.toString(16)).padZero(32)
     ])
   }
 }

--- a/src/verifiers/tree/MerkleTreeInterface.ts
+++ b/src/verifiers/tree/MerkleTreeInterface.ts
@@ -5,9 +5,9 @@ export interface MerkleTreeNode {
   encode(): Bytes
 }
 
-export interface InclusionProof {
-  siblings: Bytes
-  leafPosition: number
+export interface InclusionProof<T extends MerkleTreeNode> {
+  readonly leafPosition: number
+  readonly siblings: T[]
 }
 
 export interface MerkleTreeGenerator<T extends MerkleTreeNode> {
@@ -21,6 +21,6 @@ export interface MerkleTreeInterface<T extends MerkleTreeNode> {
   //  getInclusionProof(index: number): Bytes
 }
 
-export interface MerkleTreeVerifier<T extends MerkleTreeNode> {
-  verifyInclusion(leaf: T, root: Bytes, inclusionProof: Bytes): boolean
+export interface MerkleTreeVerifier<T extends MerkleTreeNode, I> {
+  verifyInclusion(leaf: T, root: Bytes, inclusionProof: I): boolean
 }


### PR DESCRIPTION
Adding InclusionProof interface and classes for each Tree implementation. And removing encoder and decoder of inclusion proof because InclusionProof should be encoded by appropriate format depending on use-case. For instance, it should be serialized by eth-ABI to send it to ethereum, but be serialized by an optimized binary format in local storage.



Close #98 