### PR TITLE
Fix Address-Tree

### DIFF
--- a/__tests__/verifiers/tree/AddressTree.test.ts
+++ b/__tests__/verifiers/tree/AddressTree.test.ts
@@ -40,6 +40,7 @@ describe('AddressTree', () => {
       const inclusionProof0 = tree.getInclusionProof(0)
       const inclusionProof1 = tree.getInclusionProof(1)
       expect(inclusionProof0).toStrictEqual({
+        leafIndex: Address.from('0x0000000000000000000000000000000000000000'),
         leafPosition: 0,
         siblings: [
           new AddressTreeNode(
@@ -57,6 +58,7 @@ describe('AddressTree', () => {
         ]
       })
       expect(inclusionProof1).toStrictEqual({
+        leafIndex: Address.from('0x0000000000000000000000000000000000000001'),
         leafPosition: 1,
         siblings: [
           new AddressTreeNode(
@@ -82,6 +84,7 @@ describe('AddressTree', () => {
         '0x30acf9f99796b1b310d05d35854812ff91f43cb3f35c932c0d8053bbae3a661e'
       )
       const inclusionProof = {
+        leafIndex: Address.from('0x0000000000000000000000000000000000000000'),
         leafPosition: 0,
         siblings: [
           new AddressTreeNode(
@@ -98,7 +101,12 @@ describe('AddressTree', () => {
           )
         ]
       }
-      const result = tree.verifyInclusion(leaf0, root, inclusionProof)
+      const result = tree.verifyInclusion(
+        leaf0,
+        leaf1.address,
+        root,
+        inclusionProof
+      )
       expect(result).toBeTruthy()
     })
   })

--- a/__tests__/verifiers/tree/AddressTree.test.ts
+++ b/__tests__/verifiers/tree/AddressTree.test.ts
@@ -104,6 +104,7 @@ describe('AddressTree', () => {
       const result = tree.verifyInclusion(
         leaf0,
         leaf1.address,
+        leaf1.address,
         root,
         inclusionProof
       )

--- a/__tests__/verifiers/tree/DoubleLayerTree.test.ts
+++ b/__tests__/verifiers/tree/DoubleLayerTree.test.ts
@@ -3,10 +3,10 @@ import {
   DoubleLayerTreeGenerator,
   DoubleLayerTreeLeaf,
   DoubleLayerTreeVerifier,
-  AddressTreeInclusionProof,
-  IntervalTreeInclusionProof,
+  InclusionProof,
   AddressTreeNode,
-  IntervalTreeNode
+  IntervalTreeNode,
+  DoubleLayerInclusionProof
 } from '../../../src/verifiers/tree'
 import { Bytes, BigNumber, Address, Range } from '../../../src/types'
 import { Keccak256 } from '../../../src/verifiers/hash/Keccak256'
@@ -108,78 +108,19 @@ describe('DoubleLayerTree', () => {
           1
         )
         expect(inclusionProof0).toEqual({
-          addressInclusionProof: new AddressTreeInclusionProof(0, [
-            new AddressTreeNode(
-              Address.from('0x0000000000000000000000000000000000000001'),
-              Bytes.fromHexString(
-                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-              )
-            )
-          ]),
-          intervalInclusionProof: new IntervalTreeInclusionProof(
-            BigNumber.from(0n),
+          addressInclusionProof: new InclusionProof(
+            Address.from('0x0000000000000000000000000000000000000000'),
             0,
             [
-              new IntervalTreeNode(
-                BigNumber.from(7n),
+              new AddressTreeNode(
+                Address.from('0x0000000000000000000000000000000000000001'),
                 Bytes.fromHexString(
-                  '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
-                )
-              ),
-              new IntervalTreeNode(
-                BigNumber.from(5000n),
-                Bytes.fromHexString(
-                  '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+                  '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
                 )
               )
             ]
-          )
-        })
-        expect(inclusionProof1).toEqual({
-          addressInclusionProof: new AddressTreeInclusionProof(0, [
-            new AddressTreeNode(
-              Address.from('0x0000000000000000000000000000000000000001'),
-              Bytes.fromHexString(
-                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-              )
-            )
-          ]),
-          intervalInclusionProof: new IntervalTreeInclusionProof(
-            BigNumber.from(7n),
-            1,
-            [
-              new IntervalTreeNode(
-                BigNumber.from(0n),
-                Bytes.fromHexString(
-                  '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
-                )
-              ),
-              new IntervalTreeNode(
-                BigNumber.from(5000n),
-                Bytes.fromHexString(
-                  '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
-                )
-              )
-            ]
-          )
-        })
-      })
-    })
-
-    describe('verifyInclusion', () => {
-      const validInclusionProofFor0 = {
-        addressInclusionProof: new AddressTreeInclusionProof(0, [
-          new AddressTreeNode(
-            Address.from('0x0000000000000000000000000000000000000001'),
-            Bytes.fromHexString(
-              '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-            )
-          )
-        ]),
-        intervalInclusionProof: new IntervalTreeInclusionProof(
-          BigNumber.from(0n),
-          0,
-          [
+          ),
+          intervalInclusionProof: new InclusionProof(BigNumber.from(0n), 0, [
             new IntervalTreeNode(
               BigNumber.from(7n),
               Bytes.fromHexString(
@@ -192,8 +133,67 @@ describe('DoubleLayerTree', () => {
                 '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
               )
             )
+          ])
+        })
+        expect(inclusionProof1).toEqual({
+          addressInclusionProof: new InclusionProof(
+            Address.from('0x0000000000000000000000000000000000000000'),
+            0,
+            [
+              new AddressTreeNode(
+                Address.from('0x0000000000000000000000000000000000000001'),
+                Bytes.fromHexString(
+                  '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
+                )
+              )
+            ]
+          ),
+          intervalInclusionProof: new InclusionProof(BigNumber.from(7n), 1, [
+            new IntervalTreeNode(
+              BigNumber.from(0n),
+              Bytes.fromHexString(
+                '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+              )
+            ),
+            new IntervalTreeNode(
+              BigNumber.from(5000n),
+              Bytes.fromHexString(
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+              )
+            )
+          ])
+        })
+      })
+    })
+
+    describe('verifyInclusion', () => {
+      const validInclusionProofFor0: DoubleLayerInclusionProof = {
+        addressInclusionProof: new InclusionProof(
+          Address.from('0x0000000000000000000000000000000000000000'),
+          0,
+          [
+            new AddressTreeNode(
+              Address.from('0x0000000000000000000000000000000000000001'),
+              Bytes.fromHexString(
+                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
+              )
+            )
           ]
-        )
+        ),
+        intervalInclusionProof: new InclusionProof(BigNumber.from(0n), 0, [
+          new IntervalTreeNode(
+            BigNumber.from(7n),
+            Bytes.fromHexString(
+              '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
+            )
+          ),
+          new IntervalTreeNode(
+            BigNumber.from(5000n),
+            Bytes.fromHexString(
+              '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+            )
+          )
+        ])
       }
       it('return true', async () => {
         const verifier = new DoubleLayerTreeVerifier()
@@ -214,32 +214,32 @@ describe('DoubleLayerTree', () => {
           '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const validInclusionProofFor2 = {
-          addressInclusionProof: new AddressTreeInclusionProof(0, [
-            new AddressTreeNode(
-              Address.from('0x0000000000000000000000000000000000000001'),
-              Bytes.fromHexString(
-                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-              )
-            )
-          ]),
-          intervalInclusionProof: new IntervalTreeInclusionProof(
-            BigNumber.from(15n),
-            2,
+          addressInclusionProof: new InclusionProof(
+            Address.from('0x0000000000000000000000000000000000000000'),
+            0,
             [
-              new IntervalTreeNode(
-                BigNumber.from(5000n),
+              new AddressTreeNode(
+                Address.from('0x0000000000000000000000000000000000000001'),
                 Bytes.fromHexString(
-                  '0xfdd1f2a1ec75fe968421a41d2282200de6bec6a21f81080a71b1053d9c0120f3'
-                )
-              ),
-              new IntervalTreeNode(
-                BigNumber.from(7n),
-                Bytes.fromHexString(
-                  '0x59a76952828fd54de12b708bf0030e055ae148c0a5a7d8b4f191d519275337e8'
+                  '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
                 )
               )
             ]
-          )
+          ),
+          intervalInclusionProof: new InclusionProof(BigNumber.from(15n), 2, [
+            new IntervalTreeNode(
+              BigNumber.from(5000n),
+              Bytes.fromHexString(
+                '0xfdd1f2a1ec75fe968421a41d2282200de6bec6a21f81080a71b1053d9c0120f3'
+              )
+            ),
+            new IntervalTreeNode(
+              BigNumber.from(7n),
+              Bytes.fromHexString(
+                '0x59a76952828fd54de12b708bf0030e055ae148c0a5a7d8b4f191d519275337e8'
+              )
+            )
+          ])
         }
         const result = verifier.verifyInclusion(
           leaf2,
@@ -289,32 +289,32 @@ describe('DoubleLayerTree', () => {
           '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const invalidInclusionProof = {
-          addressInclusionProof: new AddressTreeInclusionProof(0, [
-            new AddressTreeNode(
-              Address.from('0x0000000000000000000000000000000000000001'),
-              Bytes.fromHexString(
-                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-              )
-            )
-          ]),
-          intervalInclusionProof: new IntervalTreeInclusionProof(
-            BigNumber.from(0n),
+          addressInclusionProof: new InclusionProof(
+            Address.from('0x0000000000000000000000000000000000000000'),
             0,
             [
-              new IntervalTreeNode(
-                BigNumber.from(7n),
+              new AddressTreeNode(
+                Address.from('0x0000000000000000000000000000000000000001'),
                 Bytes.fromHexString(
-                  '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
-                )
-              ),
-              new IntervalTreeNode(
-                BigNumber.from(0n),
-                Bytes.fromHexString(
-                  '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+                  '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
                 )
               )
             ]
-          )
+          ),
+          intervalInclusionProof: new InclusionProof(BigNumber.from(0n), 0, [
+            new IntervalTreeNode(
+              BigNumber.from(7n),
+              Bytes.fromHexString(
+                '0x036491cc10808eeb0ff717314df6f19ba2e232d04d5f039f6fa382cae41641da'
+              )
+            ),
+            new IntervalTreeNode(
+              BigNumber.from(0n),
+              Bytes.fromHexString(
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+              )
+            )
+          ])
         }
         expect(() => {
           verifier.verifyInclusion(
@@ -331,32 +331,32 @@ describe('DoubleLayerTree', () => {
           '0x1aa3429d5aa7bf693f3879fdfe0f1a979a4b49eaeca9638fea07ad7ee5f0b64f'
         )
         const invalidInclusionProof = {
-          addressInclusionProof: new AddressTreeInclusionProof(0, [
-            new AddressTreeNode(
-              Address.from('0x0000000000000000000000000000000000000001'),
-              Bytes.fromHexString(
-                '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
-              )
-            )
-          ]),
-          intervalInclusionProof: new IntervalTreeInclusionProof(
-            BigNumber.from(7n),
-            1,
+          addressInclusionProof: new InclusionProof(
+            Address.from('0x0000000000000000000000000000000000000000'),
+            0,
             [
-              new IntervalTreeNode(
-                BigNumber.from(0n),
+              new AddressTreeNode(
+                Address.from('0x0000000000000000000000000000000000000001'),
                 Bytes.fromHexString(
-                  '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
-                )
-              ),
-              new IntervalTreeNode(
-                BigNumber.from(0n),
-                Bytes.fromHexString(
-                  '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+                  '0xdd779be20b84ced84b7cbbdc8dc98d901ecd198642313d35d32775d75d916d3a'
                 )
               )
             ]
-          )
+          ),
+          intervalInclusionProof: new InclusionProof(BigNumber.from(7n), 1, [
+            new IntervalTreeNode(
+              BigNumber.from(0n),
+              Bytes.fromHexString(
+                '0x6fef85753a1881775100d9b0a36fd6c333db4e7f358b8413d3819b6246b66a30'
+              )
+            ),
+            new IntervalTreeNode(
+              BigNumber.from(0n),
+              Bytes.fromHexString(
+                '0xef583c07cae62e3a002a9ad558064ae80db17162801132f9327e8bb6da16ea8a'
+              )
+            )
+          ])
         }
         expect(() => {
           verifier.verifyInclusion(

--- a/__tests__/verifiers/tree/IntervalTree.test.ts
+++ b/__tests__/verifiers/tree/IntervalTree.test.ts
@@ -57,7 +57,7 @@ describe('IntervalTree', () => {
       const inclusionProof0 = tree.getInclusionProof(0)
       const inclusionProof1 = tree.getInclusionProof(1)
       expect(inclusionProof0).toEqual({
-        leafStart: BigNumber.from(0n),
+        leafIndex: BigNumber.from(0n),
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
@@ -75,7 +75,7 @@ describe('IntervalTree', () => {
         ]
       })
       expect(inclusionProof1).toEqual({
-        leafStart: BigNumber.from(7n),
+        leafIndex: BigNumber.from(7n),
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
@@ -100,7 +100,7 @@ describe('IntervalTree', () => {
       const inclusionProof2 = tree.getInclusionProof(2)
       const inclusionProof3 = tree.getInclusionProof(3)
       expect(inclusionProof0).toEqual({
-        leafStart: BigNumber.from(0n),
+        leafIndex: BigNumber.from(0n),
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
@@ -118,7 +118,7 @@ describe('IntervalTree', () => {
         ]
       })
       expect(inclusionProof1).toEqual({
-        leafStart: BigNumber.from(7n),
+        leafIndex: BigNumber.from(7n),
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
@@ -136,7 +136,7 @@ describe('IntervalTree', () => {
         ]
       })
       expect(inclusionProof2).toEqual({
-        leafStart: BigNumber.from(15n),
+        leafIndex: BigNumber.from(15n),
         leafPosition: 2,
         siblings: [
           new IntervalTreeNode(
@@ -154,7 +154,7 @@ describe('IntervalTree', () => {
         ]
       })
       expect(inclusionProof3).toEqual({
-        leafStart: BigNumber.from(300n),
+        leafIndex: BigNumber.from(300n),
         leafPosition: 3,
         siblings: [
           new IntervalTreeNode(
@@ -179,7 +179,12 @@ describe('IntervalTree', () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2])
       const root = tree.getRoot()
       const inclusionProof = tree.getInclusionProof(0)
-      const result = verifier.verifyInclusion(leaf0, root, inclusionProof)
+      const result = verifier.verifyInclusion(
+        leaf0,
+        leaf1.start,
+        root,
+        inclusionProof
+      )
       expect(result).toBeTruthy()
     })
     it('return true with even number of leaves', async () => {
@@ -189,14 +194,30 @@ describe('IntervalTree', () => {
       const inclusionProof1 = tree.getInclusionProof(1)
       const inclusionProof2 = tree.getInclusionProof(2)
       const inclusionProof3 = tree.getInclusionProof(3)
-      const result0 = verifier.verifyInclusion(leaf0, root, inclusionProof0)
+      const result0 = verifier.verifyInclusion(
+        leaf0,
+        leaf1.start,
+        root,
+        inclusionProof0
+      )
       expect(result0).toBeTruthy()
-      const result1 = verifier.verifyInclusion(leaf1, root, inclusionProof1)
+      const result1 = verifier.verifyInclusion(
+        leaf1,
+        leaf2.start,
+        root,
+        inclusionProof1
+      )
       expect(result1).toBeTruthy()
-      const result2 = verifier.verifyInclusion(leaf2, root, inclusionProof2)
+      const result2 = verifier.verifyInclusion(
+        leaf2,
+        leaf3.start,
+        root,
+        inclusionProof2
+      )
       expect(result2).toBeTruthy()
       const result3 = verifier.verifyInclusion(
         leafBigNumber,
+        BigNumber.from(leafBigNumber.start.data + 1n),
         root,
         inclusionProof3
       )
@@ -206,7 +227,12 @@ describe('IntervalTree', () => {
       const tree = new IntervalTree([leaf0, leaf1, leaf2, leafBigNumber])
       const root = tree.getRoot()
       const inclusionProof0 = tree.getInclusionProof(0)
-      const result0 = verifier.verifyInclusion(leaf1, root, inclusionProof0)
+      const result0 = verifier.verifyInclusion(
+        leaf1,
+        leaf1.start,
+        root,
+        inclusionProof0
+      )
       expect(result0).toBeFalsy()
     })
     it('throw exception detecting intersection', () => {
@@ -214,7 +240,7 @@ describe('IntervalTree', () => {
         '0x91d07b5d34a03ce1831ff23c6528d2cbf64adc24e3321373dc616a6740b02577'
       )
       const invalidInclusionProof = {
-        leafStart: BigNumber.from(0n),
+        leafIndex: BigNumber.from(0n),
         leafPosition: 0,
         siblings: [
           new IntervalTreeNode(
@@ -232,7 +258,12 @@ describe('IntervalTree', () => {
         ]
       }
       expect(() => {
-        verifier.verifyInclusion(leaf0, root, invalidInclusionProof)
+        verifier.verifyInclusion(
+          leaf0,
+          leaf1.start,
+          root,
+          invalidInclusionProof
+        )
       }).toThrow(new Error('Invalid InclusionProof, intersection detected.'))
     })
     it('throw exception left.start is not less than right.start', () => {
@@ -240,7 +271,7 @@ describe('IntervalTree', () => {
         '0x91d07b5d34a03ce1831ff23c6528d2cbf64adc24e3321373dc616a6740b02577'
       )
       const invalidInclusionProof = {
-        leafStart: BigNumber.from(7n),
+        leafIndex: BigNumber.from(7n),
         leafPosition: 1,
         siblings: [
           new IntervalTreeNode(
@@ -258,7 +289,12 @@ describe('IntervalTree', () => {
         ]
       }
       expect(() => {
-        verifier.verifyInclusion(leaf1, root, invalidInclusionProof)
+        verifier.verifyInclusion(
+          leaf1,
+          leaf2.start,
+          root,
+          invalidInclusionProof
+        )
       }).toThrow(new Error('left.start is not less than right.start.'))
     })
   })

--- a/__tests__/verifiers/tree/IntervalTree.test.ts
+++ b/__tests__/verifiers/tree/IntervalTree.test.ts
@@ -181,6 +181,7 @@ describe('IntervalTree', () => {
       const inclusionProof = tree.getInclusionProof(0)
       const result = verifier.verifyInclusion(
         leaf0,
+        leaf0.start,
         leaf1.start,
         root,
         inclusionProof
@@ -196,6 +197,7 @@ describe('IntervalTree', () => {
       const inclusionProof3 = tree.getInclusionProof(3)
       const result0 = verifier.verifyInclusion(
         leaf0,
+        leaf0.start,
         leaf1.start,
         root,
         inclusionProof0
@@ -203,6 +205,7 @@ describe('IntervalTree', () => {
       expect(result0).toBeTruthy()
       const result1 = verifier.verifyInclusion(
         leaf1,
+        leaf1.start,
         leaf2.start,
         root,
         inclusionProof1
@@ -210,6 +213,7 @@ describe('IntervalTree', () => {
       expect(result1).toBeTruthy()
       const result2 = verifier.verifyInclusion(
         leaf2,
+        leaf2.start,
         leaf3.start,
         root,
         inclusionProof2
@@ -217,6 +221,7 @@ describe('IntervalTree', () => {
       expect(result2).toBeTruthy()
       const result3 = verifier.verifyInclusion(
         leafBigNumber,
+        leafBigNumber.start,
         BigNumber.from(leafBigNumber.start.data + 1n),
         root,
         inclusionProof3
@@ -229,6 +234,7 @@ describe('IntervalTree', () => {
       const inclusionProof0 = tree.getInclusionProof(0)
       const result0 = verifier.verifyInclusion(
         leaf1,
+        leaf1.start,
         leaf1.start,
         root,
         inclusionProof0
@@ -260,6 +266,7 @@ describe('IntervalTree', () => {
       expect(() => {
         verifier.verifyInclusion(
           leaf0,
+          leaf0.start,
           leaf1.start,
           root,
           invalidInclusionProof
@@ -291,6 +298,7 @@ describe('IntervalTree', () => {
       expect(() => {
         verifier.verifyInclusion(
           leaf1,
+          leaf1.start,
           leaf2.start,
           root,
           invalidInclusionProof

--- a/src/verifiers/tree/AbstractMerkleTree.ts
+++ b/src/verifiers/tree/AbstractMerkleTree.ts
@@ -117,8 +117,8 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
     )
     // computeIntervalRootAndEnd.implicitEnd < intervalEnd
     if (
-      this.compare(computeIntervalRootAndEnd.implicitEnd, intervalEnd) ||
-      this.compare(intervalStart, leaf.getInterval())
+      this.compare(computeIntervalRootAndEnd.implicitEnd, intervalEnd) == -1 ||
+      this.compare(intervalStart, leaf.getInterval()) == -1
     ) {
       throw new Error('required range must not exceed the implicit range')
     }
@@ -151,7 +151,8 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
 
         if (
           firstRightSibling &&
-          this.compare(right.getInterval(), firstRightSibling.getInterval())
+          this.compare(right.getInterval(), firstRightSibling.getInterval()) ==
+            -1
         ) {
           throw new Error('Invalid InclusionProof, intersection detected.')
         }
@@ -175,5 +176,11 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
   }
   abstract computeParent(a: T, b: T): T
   abstract createEmptyNode(): T
-  abstract compare(a: B, b: B): boolean
+  /**
+   *
+   * @param a
+   * @param b
+   * @returns 0 if they are equal, 1 if a is higher than b, -1 if a is lower than b
+   */
+  abstract compare(a: B, b: B): number
 }

--- a/src/verifiers/tree/AbstractMerkleTree.ts
+++ b/src/verifiers/tree/AbstractMerkleTree.ts
@@ -96,6 +96,7 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
   constructor(protected hashAlgorythm: Hash = Keccak256) {}
   verifyInclusion(
     leaf: T,
+    intervalStart: B,
     intervalEnd: B,
     root: Bytes,
     inclusionProof: InclusionProof<B, T>
@@ -107,10 +108,12 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
       inclusionProof.siblings
     )
     // computeIntervalRootAndEnd.implicitEnd < intervalEnd
-    if (leaf.compare(computeIntervalRootAndEnd.implicitEnd, intervalEnd)) {
+    if (
+      this.compare(computeIntervalRootAndEnd.implicitEnd, intervalEnd) ||
+      this.compare(intervalStart, leaf.getInterval())
+    ) {
       throw new Error('required range must not exceed the implicit range')
     }
-
     return computeIntervalRootAndEnd.root.equals(root)
   }
 
@@ -140,7 +143,7 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
 
         if (
           firstRightSibling &&
-          right.compare(right.getInterval(), firstRightSibling.getInterval())
+          this.compare(right.getInterval(), firstRightSibling.getInterval())
         ) {
           throw new Error('Invalid InclusionProof, intersection detected.')
         }
@@ -164,4 +167,5 @@ export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
   }
   abstract computeParent(a: T, b: T): T
   abstract createEmptyNode(): T
+  abstract compare(a: B, b: B): boolean
 }

--- a/src/verifiers/tree/AbstractMerkleTree.ts
+++ b/src/verifiers/tree/AbstractMerkleTree.ts
@@ -8,14 +8,12 @@ import { ArrayUtils, BufferUtils } from '../../utils'
 import { Hash } from '../hash/Hash'
 import { Keccak256 } from '../hash/Keccak256'
 
-export abstract class AbstractMerkleTree<
-  T extends MerkleTreeNode,
-  I extends InclusionProof<T>
-> implements MerkleTreeInterface<T> {
+export abstract class AbstractMerkleTree<B, T extends MerkleTreeNode<B>>
+  implements MerkleTreeInterface<B, T> {
   levels: T[][] = []
   constructor(
     protected leaves: T[],
-    public verifier: AbstractMerkleVerifier<T, I>
+    public verifier: AbstractMerkleVerifier<B, T>
   ) {
     this.calculateRoot(leaves, 0)
   }
@@ -48,7 +46,7 @@ export abstract class AbstractMerkleTree<
   getLeaf(index: number): T {
     return this.leaves[index]
   }
-  getInclusionProof(index: number): { leafPosition: number; siblings: T[] } {
+  getInclusionProof(index: number): InclusionProof<B, T> {
     if (!(index in this.levels[0])) {
       throw new Error(`${index} isn't in leaves.`)
     }
@@ -65,6 +63,7 @@ export abstract class AbstractMerkleTree<
       siblingIndex = this.getSiblingIndex(parentIndex)
     }
     return {
+      leafIndex: this.levels[0][index].getInterval(),
       leafPosition: index,
       siblings: inclusionProofElement
     }
@@ -93,22 +92,69 @@ export abstract class AbstractMerkleTree<
   }
 }
 
-export abstract class AbstractMerkleVerifier<
-  T extends MerkleTreeNode,
-  I extends InclusionProof<T>
-> {
+export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
   constructor(protected hashAlgorythm: Hash = Keccak256) {}
-  verifyInclusion(leaf: T, root: Bytes, inclusionProof: I): boolean {
+  verifyInclusion(
+    leaf: T,
+    intervalEnd: B,
+    root: Bytes,
+    inclusionProof: InclusionProof<B, T>
+  ): boolean {
     const merklePath = this.calculateMerklePath(inclusionProof)
-    const computeRoot = this.computeRootFromInclusionProof(
+    const computeIntervalRootAndEnd = this.computeRootFromInclusionProof(
       leaf,
       merklePath,
       inclusionProof.siblings
     )
-    return computeRoot.equals(root)
+    // computeIntervalRootAndEnd.implicitEnd < intervalEnd
+    if (leaf.compare(computeIntervalRootAndEnd.implicitEnd, intervalEnd)) {
+      throw new Error('required range must not exceed the implicit range')
+    }
+
+    return computeIntervalRootAndEnd.root.equals(root)
   }
 
-  calculateMerklePath(inclusionProof: I): string {
+  computeRootFromInclusionProof(
+    leaf: T,
+    merklePath: string,
+    proofElement: T[]
+  ): { root: Bytes; implicitEnd: B } {
+    const firstRightSiblingIndex = merklePath.indexOf('0')
+    const firstRightSibling =
+      firstRightSiblingIndex >= 0
+        ? proofElement[firstRightSiblingIndex]
+        : undefined
+
+    let computed: T = leaf
+    let left: T
+    let right: T
+    for (let i = 0; i < proofElement.length; i++) {
+      const sibling = proofElement[i]
+
+      if (merklePath[i] === '1') {
+        left = sibling
+        right = computed
+      } else {
+        left = computed
+        right = sibling
+
+        if (
+          firstRightSibling &&
+          right.compare(right.getInterval(), firstRightSibling.getInterval())
+        ) {
+          throw new Error('Invalid InclusionProof, intersection detected.')
+        }
+      }
+      // check left.index < right.index
+      computed = this.computeParent(left, right)
+    }
+    const implicitEnd = firstRightSibling
+      ? firstRightSibling.getInterval()
+      : this.createEmptyNode().getInterval()
+    return { root: computed.data, implicitEnd }
+  }
+
+  calculateMerklePath(inclusionProof: InclusionProof<B, T>): string {
     return inclusionProof.leafPosition
       .toString(2)
       .padStart(inclusionProof.siblings.length, '0')
@@ -116,11 +162,6 @@ export abstract class AbstractMerkleVerifier<
       .reverse()
       .join('')
   }
-  abstract computeRootFromInclusionProof(
-    leaf: T,
-    merklePath: string,
-    proofElement: T[]
-  ): Bytes
   abstract computeParent(a: T, b: T): T
   abstract createEmptyNode(): T
 }

--- a/src/verifiers/tree/AbstractMerkleTree.ts
+++ b/src/verifiers/tree/AbstractMerkleTree.ts
@@ -94,6 +94,14 @@ export abstract class AbstractMerkleTree<B, T extends MerkleTreeNode<B>>
 
 export abstract class AbstractMerkleVerifier<B, T extends MerkleTreeNode<B>> {
   constructor(protected hashAlgorythm: Hash = Keccak256) {}
+  /**
+   * verify inclusion of the leaf in certain range
+   * @param leaf The leaf which is included in tree
+   * @param intervalStart The start of range where the leaf is included in
+   * @param intervalEnd The end of range where the leaf is included in
+   * @param root Root hash of tree
+   * @param inclusionProof Proof data to verify inclusion of the leaf
+   */
   verifyInclusion(
     leaf: T,
     intervalStart: B,

--- a/src/verifiers/tree/AddressTree.ts
+++ b/src/verifiers/tree/AddressTree.ts
@@ -15,9 +15,6 @@ export class AddressTreeNode implements MerkleTreeNode<Address> {
   getInterval(): Address {
     return this.address
   }
-  compare(a: Address, b: Address): boolean {
-    return a.data < b.data
-  }
 }
 
 export type AddressTreeInclusionProof = InclusionProof<Address, AddressTreeNode>
@@ -45,5 +42,11 @@ export class AddressTreeVerifier extends AbstractMerkleVerifier<
   createEmptyNode(): AddressTreeNode {
     // TODO: empty node shouldn't be zero address?
     return new AddressTreeNode(Address.default(), Bytes.default())
+  }
+  /**
+   * compare Address
+   */
+  compare(a: Address, b: Address): boolean {
+    return a.data < b.data
   }
 }

--- a/src/verifiers/tree/AddressTree.ts
+++ b/src/verifiers/tree/AddressTree.ts
@@ -46,7 +46,9 @@ export class AddressTreeVerifier extends AbstractMerkleVerifier<
   /**
    * compare Address
    */
-  compare(a: Address, b: Address): boolean {
-    return a.data < b.data
+  compare(a: Address, b: Address): number {
+    if (a.data > b.data) return 1
+    else if (a.data == b.data) return 0
+    else return -1
   }
 }

--- a/src/verifiers/tree/DoubleLayerTree.ts
+++ b/src/verifiers/tree/DoubleLayerTree.ts
@@ -47,12 +47,6 @@ export class DoubleLayerTreeLeaf
       start: this.start
     }
   }
-  compare(a: DoubleLayerInterval, b: DoubleLayerInterval): boolean {
-    if (a.address.data == b.address.data) {
-      return a.start.data < b.start.data
-    }
-    return a.address.data < b.address.data
-  }
 }
 
 export class DoubleLayerTreeGenerator
@@ -185,6 +179,7 @@ export class DoubleLayerTreeVerifier implements DoubleLayerTreeVerifier {
     }
     return addressTreeVerifier.verifyInclusion(
       new AddressTreeNode(leaf.address, computeIntervalRootAndEnd.root),
+      leaf.address,
       leaf.address,
       root,
       inclusionProof.addressInclusionProof

--- a/src/verifiers/tree/IntervalTree.ts
+++ b/src/verifiers/tree/IntervalTree.ts
@@ -24,9 +24,6 @@ export class IntervalTreeNode implements MerkleTreeNode<BigNumber> {
       Bytes.fromHexString(this.start.data.toString(16)).padZero(32)
     ])
   }
-  compare(a: BigNumber, b: BigNumber): boolean {
-    return a.data < b.data
-  }
 }
 
 export class IntervalTree extends AbstractMerkleTree<
@@ -73,5 +70,11 @@ export class IntervalTreeVerifier extends AbstractMerkleVerifier<
       BigNumber.MAX_NUMBER,
       this.hashAlgorythm.hash(Bytes.default())
     )
+  }
+  /**
+   * compare BigNumber
+   */
+  compare(a: BigNumber, b: BigNumber): boolean {
+    return a.data < b.data
   }
 }

--- a/src/verifiers/tree/IntervalTree.ts
+++ b/src/verifiers/tree/IntervalTree.ts
@@ -74,7 +74,9 @@ export class IntervalTreeVerifier extends AbstractMerkleVerifier<
   /**
    * compare BigNumber
    */
-  compare(a: BigNumber, b: BigNumber): boolean {
-    return a.data < b.data
+  compare(a: BigNumber, b: BigNumber): number {
+    if (a.data > b.data) return 1
+    else if (a.data == b.data) return 0
+    else return -1
   }
 }

--- a/src/verifiers/tree/IntervalTree.ts
+++ b/src/verifiers/tree/IntervalTree.ts
@@ -1,21 +1,12 @@
-import { Bytes, BigNumber } from '../../types'
+import { Bytes, BigNumber, Integer } from '../../types'
 import {
   AbstractMerkleTree,
   AbstractMerkleVerifier
 } from './AbstractMerkleTree'
-import { InclusionProof, MerkleTreeNode } from './MerkleTreeInterface'
+import { MerkleTreeNode } from './MerkleTreeInterface'
 import { BigIntMath } from '../../utils'
 
-export class IntervalTreeInclusionProof
-  implements InclusionProof<IntervalTreeNode> {
-  constructor(
-    public leafStart: BigNumber,
-    public leafPosition: number,
-    public siblings: IntervalTreeNode[]
-  ) {}
-}
-
-export class IntervalTreeNode implements MerkleTreeNode {
+export class IntervalTreeNode implements MerkleTreeNode<BigNumber> {
   /**
    *
    * @param start is 32 byte integer and lower bound of range.
@@ -24,28 +15,26 @@ export class IntervalTreeNode implements MerkleTreeNode {
   constructor(public start: BigNumber, public data: Bytes) {
     if (data.data.length !== 32) throw new Error('data length is not 32 bytes.')
   }
+  getInterval(): BigNumber {
+    return this.start
+  }
   encode(): Bytes {
     return Bytes.concat([
       this.data,
       Bytes.fromHexString(this.start.data.toString(16)).padZero(32)
     ])
   }
+  compare(a: BigNumber, b: BigNumber): boolean {
+    return a.data < b.data
+  }
 }
 
 export class IntervalTree extends AbstractMerkleTree<
-  IntervalTreeNode,
-  IntervalTreeInclusionProof
+  BigNumber,
+  IntervalTreeNode
 > {
   constructor(leaves: IntervalTreeNode[]) {
     super(leaves, new IntervalTreeVerifier())
-  }
-  getInclusionProof(index: number): IntervalTreeInclusionProof {
-    const inclusionProof = super.getInclusionProof(index)
-    return new IntervalTreeInclusionProof(
-      this.levels[0][index].start,
-      inclusionProof.leafPosition,
-      inclusionProof.siblings
-    )
   }
 
   getLeaves(start: bigint, end: bigint): number[] {
@@ -66,56 +55,9 @@ export class IntervalTree extends AbstractMerkleTree<
 }
 
 export class IntervalTreeVerifier extends AbstractMerkleVerifier<
-  IntervalTreeNode,
-  IntervalTreeInclusionProof
+  BigNumber,
+  IntervalTreeNode
 > {
-  computeRootFromInclusionProof(
-    leaf: IntervalTreeNode,
-    merklePath: string,
-    proofElement: IntervalTreeNode[]
-  ): Bytes {
-    return this.computeRootAndImplicitEnd(leaf, merklePath, proofElement).root
-  }
-  computeRootAndImplicitEnd(
-    leaf: IntervalTreeNode,
-    merklePath: string,
-    proofElement: IntervalTreeNode[]
-  ): { root: Bytes; implicitEnd: BigNumber } {
-    const firstRightSiblingIndex = merklePath.indexOf('0')
-    const firstRightSibling =
-      firstRightSiblingIndex >= 0
-        ? proofElement[firstRightSiblingIndex]
-        : undefined
-
-    let computed: IntervalTreeNode = leaf
-    let left: IntervalTreeNode
-    let right: IntervalTreeNode
-    for (let i = 0; i < proofElement.length; i++) {
-      const sibling = proofElement[i]
-
-      if (merklePath[i] === '1') {
-        left = sibling
-        right = computed
-      } else {
-        left = computed
-        right = sibling
-
-        if (
-          firstRightSibling &&
-          right.start.data < firstRightSibling.start.data
-        ) {
-          throw new Error('Invalid InclusionProof, intersection detected.')
-        }
-      }
-      // check left.index < right.index
-      computed = this.computeParent(left, right)
-    }
-    const implicitEnd = firstRightSibling
-      ? firstRightSibling.start
-      : this.createEmptyNode().start
-    return { root: computed.data, implicitEnd }
-  }
-
   computeParent(a: IntervalTreeNode, b: IntervalTreeNode): IntervalTreeNode {
     if (a.start.data > b.start.data) {
       throw new Error('left.start is not less than right.start.')

--- a/src/verifiers/tree/MerkleTreeInterface.ts
+++ b/src/verifiers/tree/MerkleTreeInterface.ts
@@ -1,25 +1,30 @@
-import { Address, Bytes, Struct } from '../../types'
+import { Bytes } from '../../types'
 
-export interface MerkleTreeNode {
+export interface MerkleTreeNode<T> {
   readonly data: Bytes
+  getInterval(): T
   encode(): Bytes
+  compare(a: T, b: T): boolean
 }
 
-export interface InclusionProof<T extends MerkleTreeNode> {
-  readonly leafPosition: number
-  readonly siblings: T[]
+export interface MerkleTreeGenerator<I, T extends MerkleTreeNode<I>> {
+  generate(leaves: T[]): MerkleTreeInterface<I, T>
 }
 
-export interface MerkleTreeGenerator<T extends MerkleTreeNode> {
-  generate(leaves: T[]): MerkleTreeInterface<T>
-}
-
-export interface MerkleTreeInterface<T extends MerkleTreeNode> {
+export interface MerkleTreeInterface<I, T extends MerkleTreeNode<I>> {
   getRoot(): Bytes
   findIndex(leaf: Bytes): number | null
   getLeaf(index: number): T
 }
 
-export interface MerkleTreeVerifier<T extends MerkleTreeNode, I> {
-  verifyInclusion(leaf: T, root: Bytes, inclusionProof: I): boolean
+export interface MerkleTreeVerifier<B, T extends MerkleTreeNode<I>, I> {
+  verifyInclusion(leaf: T, interval: B, root: Bytes, inclusionProof: I): boolean
+}
+
+export class InclusionProof<I, T extends MerkleTreeNode<I>> {
+  constructor(
+    readonly leafIndex: I,
+    readonly leafPosition: number,
+    readonly siblings: T[]
+  ) {}
 }

--- a/src/verifiers/tree/MerkleTreeInterface.ts
+++ b/src/verifiers/tree/MerkleTreeInterface.ts
@@ -4,7 +4,6 @@ export interface MerkleTreeNode<T> {
   readonly data: Bytes
   getInterval(): T
   encode(): Bytes
-  compare(a: T, b: T): boolean
 }
 
 export interface MerkleTreeGenerator<I, T extends MerkleTreeNode<I>> {


### PR DESCRIPTION
### Why

To make token-address not to overwrap, the address should be verified as an interval in Address-Tree.

figure 0. This is an example of invalid address tree.

```
         /           \
     /     \      /     \
address0, address1, address0, address2
```

### What

The address-tree and interval-tree(I should call it BigNumber-interval-tree to avoid confusion) can inherit the same [Abstract-Merkle-Tree class](https://github.com/cryptoeconomicslab/wakkanay/pull/113/files#diff-34f49645e00a1d576376fcc18f57fe89) and Abstract-Merkle-Tree is Merkle Interval Tree. Normal Interval-tree's interval is calculated by `BigNumber` and Address-tree's interval is calculated by `Address`.

The verifier throws [an exception](https://github.com/cryptoeconomicslab/wakkanay/pull/113/files#diff-34f49645e00a1d576376fcc18f57fe89R123) when it verifies the tree describing in figure 0 above.

### Remaining Tasks

- In the case of that, there is an exclusion over multiple tokens

Close #24 
