### PR TITLE
clean(ovm): Clean test code of NotDecider using the mock decider manager

### DIFF
--- a/__tests__/ovm/deciders/AndDecider.test.ts
+++ b/__tests__/ovm/deciders/AndDecider.test.ts
@@ -1,50 +1,66 @@
-import { Property } from '../../../src/ovm/types'
+import {
+  Property,
+  LogicalConnective,
+  AtomicPredicate
+} from '../../../src/ovm/types'
 import { Bytes, Integer } from '../../../src/types/Codables'
 import DefaultCoder from '../../../src/coder'
-import {
-  initializeDeciderManager,
-  AndDeciderAddress,
-  NotDeciderAddress,
-  SampleDeciderAddress
-} from '../helpers/initiateDeciderManager'
+import { AndDecider } from '../../../src/ovm/deciders'
+import { MockDeciderManager } from '../mocks/MockDeciderManager'
 
 describe('AndDecider', () => {
+  const deciderManager = new MockDeciderManager()
+  const NotDeciderAddress = deciderManager.getDeciderAddress(
+    LogicalConnective.Not
+  )
+  const BoolDeciderAddress = deciderManager.getDeciderAddress(
+    AtomicPredicate.Bool
+  )
   const trueProperty = DefaultCoder.encode(
-    new Property(SampleDeciderAddress, [Bytes.fromString('true')]).toStruct()
+    new Property(BoolDeciderAddress, [Bytes.fromString('true')]).toStruct()
   )
   const falseProperty = DefaultCoder.encode(
-    new Property(SampleDeciderAddress, []).toStruct()
+    new Property(BoolDeciderAddress, []).toStruct()
   )
-  const deciderManager = initializeDeciderManager()
   const challengeInput0 = DefaultCoder.encode(Integer.from(0))
   const challengeInput1 = DefaultCoder.encode(Integer.from(1))
 
   it('decide and(true, true)', async () => {
-    const decision = await deciderManager.decide(
-      new Property(AndDeciderAddress, [trueProperty, trueProperty])
-    )
+    const andDecider = new AndDecider()
+    const decision = await andDecider.decide(deciderManager, [
+      trueProperty,
+      trueProperty
+    ])
     expect(decision.outcome).toEqual(true)
   })
   it('decide and(true, false)', async () => {
-    const decision = await deciderManager.decide(
-      new Property(AndDeciderAddress, [trueProperty, falseProperty])
-    )
+    const andDecider = new AndDecider()
+    const decision = await andDecider.decide(deciderManager, [
+      trueProperty,
+      falseProperty
+    ])
     expect(decision.outcome).toEqual(false)
     // valid challenge is Not(SampleDecider(false))
-    expect(decision.challenges[0]).toEqual({
-      challengeInput: challengeInput1,
-      property: new Property(NotDeciderAddress, [falseProperty])
-    })
+    expect(decision.challenges).toEqual([
+      {
+        challengeInput: challengeInput1,
+        property: new Property(NotDeciderAddress, [falseProperty])
+      }
+    ])
   })
   it('decide and(false, true)', async () => {
-    const decision = await deciderManager.decide(
-      new Property(AndDeciderAddress, [falseProperty, trueProperty])
-    )
+    const andDecider = new AndDecider()
+    const decision = await andDecider.decide(deciderManager, [
+      falseProperty,
+      trueProperty
+    ])
     expect(decision.outcome).toEqual(false)
     // valid challenge is Not(SampleDecider(false))
-    expect(decision.challenges[0]).toEqual({
-      challengeInput: challengeInput0,
-      property: new Property(NotDeciderAddress, [falseProperty])
-    })
+    expect(decision.challenges).toEqual([
+      {
+        challengeInput: challengeInput0,
+        property: new Property(NotDeciderAddress, [falseProperty])
+      }
+    ])
   })
 })

--- a/__tests__/ovm/deciders/NotDecider.test.ts
+++ b/__tests__/ovm/deciders/NotDecider.test.ts
@@ -1,33 +1,41 @@
 import { Property } from '../../../src/ovm/types'
-import { Bytes } from '../../../src/types/Codables'
+import { Bytes, Address } from '../../../src/types/Codables'
 import Coder from '../../../src/coder'
-import {
-  initializeDeciderManager,
-  NotDeciderAddress,
-  SampleDeciderAddress
-} from '../helpers/initiateDeciderManager'
+import { NotDecider } from '../../../src/ovm/deciders/operators/NotDecider'
+import { MockDeciderManager } from '../mocks/MockDeciderManager'
 
 describe('NotDecider', () => {
-  const trueProperty = new Property(SampleDeciderAddress, [
+  const trueProperty = new Property(Address.default(), [
     Bytes.fromString('true')
   ])
-  const falseProperty = new Property(SampleDeciderAddress, [])
-  const deciderManager = initializeDeciderManager()
+  const falseProperty = new Property(Address.default(), [])
   it('decide not(false)', async () => {
-    const decision = await deciderManager.decide(
-      new Property(NotDeciderAddress, [Coder.encode(falseProperty.toStruct())])
-    )
+    const deciderManager = new MockDeciderManager({
+      outcome: false,
+      challenges: []
+    })
+    const nodeDecider = new NotDecider()
+    const decision = await nodeDecider.decide(deciderManager, [
+      Coder.encode(falseProperty.toStruct())
+    ])
     expect(decision.outcome).toEqual(true)
   })
   it('decide not(true)', async () => {
-    const decision = await deciderManager.decide(
-      new Property(NotDeciderAddress, [Coder.encode(trueProperty.toStruct())])
-    )
+    const deciderManager = new MockDeciderManager({
+      outcome: true,
+      challenges: []
+    })
+    const nodeDecider = new NotDecider()
+    const decision = await nodeDecider.decide(deciderManager, [
+      Coder.encode(trueProperty.toStruct())
+    ])
     expect(decision.outcome).toEqual(false)
     // valid challenge is SampleDecider(true)
-    expect(decision.challenges[0]).toEqual({
-      challengeInput: null,
-      property: trueProperty
-    })
+    expect(decision.challenges).toEqual([
+      {
+        challengeInput: null,
+        property: trueProperty
+      }
+    ])
   })
 })

--- a/__tests__/ovm/deciders/NotDecider.test.ts
+++ b/__tests__/ovm/deciders/NotDecider.test.ts
@@ -1,19 +1,19 @@
-import { Property } from '../../../src/ovm/types'
+import { Property, AtomicPredicate } from '../../../src/ovm/types'
 import { Bytes, Address } from '../../../src/types/Codables'
 import Coder from '../../../src/coder'
-import { NotDecider } from '../../../src/ovm/deciders/operators/NotDecider'
+import { NotDecider } from '../../../src/ovm/deciders'
 import { MockDeciderManager } from '../mocks/MockDeciderManager'
 
 describe('NotDecider', () => {
-  const trueProperty = new Property(Address.default(), [
+  const deciderManager = new MockDeciderManager()
+  const BoolDeciderAddress = deciderManager.getDeciderAddress(
+    AtomicPredicate.Bool
+  )
+  const trueProperty = new Property(BoolDeciderAddress, [
     Bytes.fromString('true')
   ])
-  const falseProperty = new Property(Address.default(), [])
+  const falseProperty = new Property(BoolDeciderAddress, [])
   it('decide not(false)', async () => {
-    const deciderManager = new MockDeciderManager({
-      outcome: false,
-      challenges: []
-    })
     const nodeDecider = new NotDecider()
     const decision = await nodeDecider.decide(deciderManager, [
       Coder.encode(falseProperty.toStruct())
@@ -21,10 +21,6 @@ describe('NotDecider', () => {
     expect(decision.outcome).toEqual(true)
   })
   it('decide not(true)', async () => {
-    const deciderManager = new MockDeciderManager({
-      outcome: true,
-      challenges: []
-    })
     const nodeDecider = new NotDecider()
     const decision = await nodeDecider.decide(deciderManager, [
       Coder.encode(trueProperty.toStruct())

--- a/__tests__/ovm/deciders/OrDecider.test.ts
+++ b/__tests__/ovm/deciders/OrDecider.test.ts
@@ -1,60 +1,79 @@
-import { Property } from '../../../src/ovm/types'
-import { Bytes } from '../../../src/types/Codables'
 import {
-  initializeDeciderManager,
-  OrDeciderAddress,
-  NotDeciderAddress,
-  SampleDeciderAddress,
-  AndDeciderAddress
-} from '../helpers/initiateDeciderManager'
+  AtomicPredicate,
+  LogicalConnective,
+  Property
+} from '../../../src/ovm/types'
+import { Bytes } from '../../../src/types/Codables'
+import { OrDecider } from '../../../src/ovm/deciders'
+import { MockDeciderManager } from '../mocks/MockDeciderManager'
 import { encodeProperty } from '../../../src/ovm/helpers'
 
 describe('OrDecider', () => {
-  const trueProperty = encodeProperty(
-    new Property(SampleDeciderAddress, [Bytes.fromString('true')])
+  const deciderManager = new MockDeciderManager()
+  const NotDeciderAddress = deciderManager.getDeciderAddress(
+    LogicalConnective.Not
   )
-  const falseProperty = encodeProperty(new Property(SampleDeciderAddress, []))
-  const deciderManager = initializeDeciderManager()
+  const AndDeciderAddress = deciderManager.getDeciderAddress(
+    LogicalConnective.And
+  )
+  const BoolDeciderAddress = deciderManager.getDeciderAddress(
+    AtomicPredicate.Bool
+  )
+  const trueProperty = encodeProperty(
+    new Property(BoolDeciderAddress, [Bytes.fromString('true')])
+  )
+  const falseProperty = encodeProperty(new Property(BoolDeciderAddress, []))
   test('decide or(false, false) to false', async () => {
-    const decision = await deciderManager.decide(
-      new Property(OrDeciderAddress, [falseProperty, falseProperty])
-    )
+    const orDecier = new OrDecider()
+    const decision = await orDecier.decide(deciderManager, [
+      falseProperty,
+      falseProperty
+    ])
     expect(decision.outcome).toEqual(false)
     // valid challenge is And(Not(P0), Not(P1))
-    expect(decision.challenges[0]).toEqual({
-      property: new Property(AndDeciderAddress, [
-        encodeProperty(new Property(NotDeciderAddress, [falseProperty])),
-        encodeProperty(new Property(NotDeciderAddress, [falseProperty]))
-      ]),
-      challengeInput: null
-    })
+    expect(decision.challenges).toEqual([
+      {
+        property: new Property(AndDeciderAddress, [
+          encodeProperty(new Property(NotDeciderAddress, [falseProperty])),
+          encodeProperty(new Property(NotDeciderAddress, [falseProperty]))
+        ]),
+        challengeInput: null
+      }
+    ])
   })
 
   test('decide or(false, true) to true', async () => {
-    const decision = await deciderManager.decide(
-      new Property(OrDeciderAddress, [falseProperty, trueProperty])
-    )
+    const orDecier = new OrDecider()
+    const decision = await orDecier.decide(deciderManager, [
+      falseProperty,
+      trueProperty
+    ])
     expect(decision.outcome).toEqual(true)
   })
 
   test('decide or(true, false) to true', async () => {
-    const decision = await deciderManager.decide(
-      new Property(OrDeciderAddress, [trueProperty, falseProperty])
-    )
+    const orDecier = new OrDecider()
+    const decision = await orDecier.decide(deciderManager, [
+      trueProperty,
+      falseProperty
+    ])
     expect(decision.outcome).toEqual(true)
   })
 
   test('decide or(true, true) to true', async () => {
-    const decision = await deciderManager.decide(
-      new Property(OrDeciderAddress, [trueProperty, trueProperty])
-    )
+    const orDecier = new OrDecider()
+    const decision = await orDecier.decide(deciderManager, [
+      trueProperty,
+      trueProperty
+    ])
     expect(decision.outcome).toEqual(true)
   })
 
   test('decide to false if given non-property input type.', async () => {
-    const decision = await deciderManager.decide(
-      new Property(OrDeciderAddress, [Bytes.fromString('Hello')])
-    )
+    const orDecier = new OrDecider()
+    const decision = await orDecier.decide(deciderManager, [
+      Bytes.fromString('Hello')
+    ])
     expect(decision.outcome).toEqual(false)
   })
 })

--- a/__tests__/ovm/mocks/MockDeciderManager.ts
+++ b/__tests__/ovm/mocks/MockDeciderManager.ts
@@ -1,0 +1,13 @@
+import { Bytes } from '../../../src/types/Codables'
+import { Property, Decision } from '../../../src/ovm/types'
+import { DeciderManagerInterface } from '../../../src/ovm'
+
+export class MockDeciderManager implements DeciderManagerInterface {
+  constructor(readonly decision: Decision) {}
+  public async decide(
+    property: Property,
+    substitutions: { [key: string]: Bytes } = {}
+  ): Promise<Decision> {
+    return this.decision
+  }
+}

--- a/__tests__/ovm/mocks/MockDeciderManager.ts
+++ b/__tests__/ovm/mocks/MockDeciderManager.ts
@@ -1,13 +1,48 @@
-import { Bytes } from '../../../src/types/Codables'
+import { Bytes, Address } from '../../../src/types/Codables'
 import { Property, Decision } from '../../../src/ovm/types'
-import { DeciderManagerInterface } from '../../../src/ovm'
+import {
+  AtomicPredicate,
+  DeciderManagerInterface,
+  LogicalConnective
+} from '../../../src/ovm'
+
+export const BoolDeciderAddress = Address.from(
+  '0x0000000000000000000000000000000000000001'
+)
+const NotDeciderAddress = Address.from(
+  '0x0000000000000000000000000000000000000002'
+)
+const AndDeciderAddress = Address.from(
+  '0x0000000000000000000000000000000000000003'
+)
+const ForAllSuchThatDeciderAddress = Address.from(
+  '0x0000000000000000000000000000000000000004'
+)
 
 export class MockDeciderManager implements DeciderManagerInterface {
-  constructor(readonly decision: Decision) {}
+  constructor() {}
   public async decide(
     property: Property,
     substitutions: { [key: string]: Bytes } = {}
   ): Promise<Decision> {
-    return this.decision
+    return {
+      outcome:
+        property.inputs.length > 0 &&
+        property.inputs[0].intoString() === 'true',
+      challenges: []
+    }
+  }
+  getDeciderAddress(operator: LogicalConnective | AtomicPredicate): Address {
+    if (operator == LogicalConnective.Not) {
+      return NotDeciderAddress
+    } else if (operator == LogicalConnective.And) {
+      return AndDeciderAddress
+    } else if (operator == LogicalConnective.ForAllSuchThat) {
+      return ForAllSuchThatDeciderAddress
+    } else if (operator == AtomicPredicate.Bool) {
+      return BoolDeciderAddress
+    } else {
+      throw new Error(`perator ${operator} is not registered.`)
+    }
   }
 }

--- a/__tests__/ovm/mocks/MockDeciderManager.ts
+++ b/__tests__/ovm/mocks/MockDeciderManager.ts
@@ -3,10 +3,11 @@ import { Property, Decision } from '../../../src/ovm/types'
 import {
   AtomicPredicate,
   DeciderManagerInterface,
-  LogicalConnective
+  LogicalConnective,
+  OrDecider
 } from '../../../src/ovm'
 
-export const BoolDeciderAddress = Address.from(
+const BoolDeciderAddress = Address.from(
   '0x0000000000000000000000000000000000000001'
 )
 const NotDeciderAddress = Address.from(
@@ -17,6 +18,9 @@ const AndDeciderAddress = Address.from(
 )
 const ForAllSuchThatDeciderAddress = Address.from(
   '0x0000000000000000000000000000000000000004'
+)
+const OrDeciderAddress = Address.from(
+  '0x0000000000000000000000000000000000000009'
 )
 
 export class MockDeciderManager implements DeciderManagerInterface {
@@ -39,6 +43,8 @@ export class MockDeciderManager implements DeciderManagerInterface {
       return AndDeciderAddress
     } else if (operator == LogicalConnective.ForAllSuchThat) {
       return ForAllSuchThatDeciderAddress
+    } else if (operator == LogicalConnective.Or) {
+      return OrDeciderAddress
     } else if (operator == AtomicPredicate.Bool) {
       return BoolDeciderAddress
     } else {

--- a/src/ovm/DeciderManager.ts
+++ b/src/ovm/DeciderManager.ts
@@ -10,10 +10,17 @@ import {
 import { Quantifier } from './interfaces/Quantifier'
 import { KeyValueStore } from '../db'
 
+export interface DeciderManagerInterface {
+  decide(
+    property: Property,
+    substitutions?: { [key: string]: Bytes }
+  ): Promise<Decision>
+}
+
 /**
  * DeciderManager manages deciders and its address
  */
-export class DeciderManager {
+export class DeciderManager implements DeciderManagerInterface {
   private deciders: Map<string, Decider>
   private operators: Map<LogicalConnective | AtomicPredicate, Address>
   private quantifiers: Map<string, Quantifier>

--- a/src/ovm/DeciderManager.ts
+++ b/src/ovm/DeciderManager.ts
@@ -15,6 +15,7 @@ export interface DeciderManagerInterface {
     property: Property,
     substitutions?: { [key: string]: Bytes }
   ): Promise<Decision>
+  getDeciderAddress(operator: LogicalConnective | AtomicPredicate): Address
 }
 
 /**

--- a/src/ovm/deciders/operators/AndDecider.ts
+++ b/src/ovm/deciders/operators/AndDecider.ts
@@ -2,7 +2,7 @@ import Coder from '../../../coder'
 import { Bytes, Integer } from '../../../types/Codables'
 import { Decider } from '../../interfaces/Decider'
 import { Decision, Property, Challenge, LogicalConnective } from '../../types'
-import { DeciderManager } from '../../DeciderManager'
+import { DeciderManagerInterface } from '../../DeciderManager'
 import { decodeProperty } from '../../helpers'
 
 /**
@@ -11,7 +11,7 @@ import { decodeProperty } from '../../helpers'
  */
 export class AndDecider implements Decider {
   public async decide(
-    manager: DeciderManager,
+    manager: DeciderManagerInterface,
     inputs: Bytes[]
   ): Promise<Decision> {
     let properties

--- a/src/ovm/deciders/operators/NotDecider.ts
+++ b/src/ovm/deciders/operators/NotDecider.ts
@@ -2,7 +2,7 @@ import { Bytes } from '../../../types/Codables'
 import Coder from '../../../coder'
 import { Decider } from '../../interfaces/Decider'
 import { Decision, Property } from '../../types'
-import { DeciderManager } from '../../DeciderManager'
+import { DeciderManagerInterface } from '../../DeciderManager'
 
 /**
  * NotDecider recieves one input and returns logical negation of its decision.
@@ -10,7 +10,7 @@ import { DeciderManager } from '../../DeciderManager'
  */
 export class NotDecider implements Decider {
   public async decide(
-    manager: DeciderManager,
+    manager: DeciderManagerInterface,
     inputs: Bytes[],
     substitutions: { [key: string]: Bytes } = {}
   ): Promise<Decision> {

--- a/src/ovm/deciders/operators/OrDecider.ts
+++ b/src/ovm/deciders/operators/OrDecider.ts
@@ -1,12 +1,12 @@
 import { Bytes } from '../../../types/Codables'
 import { Decider } from '../../interfaces/Decider'
 import { Decision, Property, LogicalConnective } from '../../types'
-import { DeciderManager } from '../../DeciderManager'
+import { DeciderManagerInterface } from '../../DeciderManager'
 import { encodeProperty, decodeProperty } from '../../helpers'
 
 export class OrDecider implements Decider {
   public async decide(
-    manager: DeciderManager,
+    manager: DeciderManagerInterface,
     inputs: Bytes[]
   ): Promise<Decision> {
     let properties: Array<Property>

--- a/src/ovm/interfaces/Decider.ts
+++ b/src/ovm/interfaces/Decider.ts
@@ -1,10 +1,10 @@
 import { Bytes } from '../../types/Codables'
 import { Decision } from '../types'
-import { DeciderManager } from '../DeciderManager'
+import { DeciderManagerInterface } from '../DeciderManager'
 
 export interface Decider {
   decide(
-    manager: DeciderManager,
+    manager: DeciderManagerInterface,
     inputs: Bytes[],
     substitutions: { [key: string]: Bytes }
   ): Promise<Decision>


### PR DESCRIPTION
This is a proposition to remove the dependency on DeciderManager from test code.
This PR is halfway.

- [x] NotDecider
- [x] AndDecider
- [x] OrDecider
- [ ] ForAllSuchThatDecider
- [ ] ThereExistsSuchThatDecider
