### PR TITLE
fix verification logic of Secp256k1

### DIFF
--- a/__tests__/ovm/deciders/IsValidSignatureDecider.test.ts
+++ b/__tests__/ovm/deciders/IsValidSignatureDecider.test.ts
@@ -3,12 +3,14 @@ import { IsValidSignatureDecider } from '../../../src/ovm/deciders'
 import { Property } from '../../../src/ovm/types'
 import { Address, Bytes } from '../../../src/types/Codables'
 import * as ethers from 'ethers'
-import { SigningKey, arrayify, joinSignature } from 'ethers/utils'
+import { SigningKey, arrayify, joinSignature, keccak256 } from 'ethers/utils'
 import { InMemoryKeyValueStore } from '../../../src/db'
 
 function sign(message: Bytes, key: SigningKey): Bytes {
   return Bytes.fromHexString(
-    joinSignature(key.signDigest(arrayify(message.toHexString())))
+    joinSignature(
+      key.signDigest(arrayify(keccak256(arrayify(message.toHexString()))))
+    )
   )
 }
 
@@ -34,7 +36,7 @@ describe('IsValidSignatureDecider', () => {
     const property = new Property(addr, [
       message,
       signature,
-      Bytes.fromString(Address.from(publicKey).raw),
+      Bytes.fromHexString(Address.from(publicKey).raw),
       Bytes.fromString('secp256k1')
     ])
 
@@ -46,7 +48,7 @@ describe('IsValidSignatureDecider', () => {
     const property = new Property(addr, [
       message,
       Bytes.fromString('hellohello'),
-      Bytes.fromString(Address.from(publicKey).raw),
+      Bytes.fromHexString(Address.from(publicKey).raw),
       Bytes.fromString('secp256k1')
     ])
 
@@ -59,7 +61,7 @@ describe('IsValidSignatureDecider', () => {
     const property = new Property(addr, [
       message,
       invalidSig,
-      Bytes.fromString(Address.from(publicKey).raw),
+      Bytes.fromHexString(Address.from(publicKey).raw),
       Bytes.fromString('secp256k1')
     ])
 
@@ -71,7 +73,7 @@ describe('IsValidSignatureDecider', () => {
     const property = new Property(addr, [
       message,
       signature,
-      Bytes.fromString(Address.from(publicKey).raw),
+      Bytes.fromHexString(Address.from(publicKey).raw),
       Bytes.fromString('ed25519')
     ])
 

--- a/__tests__/ovm/deciders/ThereExistsSuchThatDecider.test.ts
+++ b/__tests__/ovm/deciders/ThereExistsSuchThatDecider.test.ts
@@ -68,11 +68,11 @@ describe('ThereExistsSuchThatDecider', () => {
       Bytes.fromString('sig')
     )
     const publicKey = Bytes.fromHexString(
-      '0x307836323733303630393061626142334136653134303065393334356243363063373861384245663537'
+      '0x5640A00fAE03fa40d527C27dc28E67dF140Fd995'
     )
     const message = Bytes.fromString('message')
     const signature = Bytes.fromHexString(
-      '0x38e654295143721adf1e23753c82899022ad3742e33e2472068f1612736b537576f1406b3fc372ff081d5a5785bdc453afbdc5ac07eff710796a06c69a786f9b1c'
+      '0x682f001aa66b904779bbcd846e52a62f4cf7d643b91826fdec04441ab604a6d66330609ad20a1a14fb52e3967bd2086c131e634ee4823b8a7ce3be8d91038daa1b'
     )
 
     await sigBucket.put(message, signature)

--- a/__tests__/verifiers/Secp256k1.test.ts
+++ b/__tests__/verifiers/Secp256k1.test.ts
@@ -3,11 +3,11 @@ import { Bytes } from '../../src/types/Codables'
 
 describe('secp256k1Verifier', () => {
   const publicKey = Bytes.fromHexString(
-    '0x307836323733303630393061626142334136653134303065393334356243363063373861384245663537'
+    '0x5640A00fAE03fa40d527C27dc28E67dF140Fd995'
   )
   const message = Bytes.fromString('message')
   const signature = Bytes.fromHexString(
-    '0x38e654295143721adf1e23753c82899022ad3742e33e2472068f1612736b537576f1406b3fc372ff081d5a5785bdc453afbdc5ac07eff710796a06c69a786f9b1c'
+    '0x682f001aa66b904779bbcd846e52a62f4cf7d643b91826fdec04441ab604a6d66330609ad20a1a14fb52e3967bd2086c131e634ee4823b8a7ce3be8d91038daa1b'
   )
   const invalidSignature = Bytes.fromHexString(
     '0x258be95aa1b4b86ca2a931bc95a648b2be79e8002e93ea4ffb416ad526b676a87e1776ebe8b0ea861b4e797c82023146de0b930b86ea49aa0fb2b9fcc5f30b931b'

--- a/src/verifiers/Secp256k1.ts
+++ b/src/verifiers/Secp256k1.ts
@@ -1,13 +1,21 @@
-import { splitSignature, recoverAddress } from 'ethers/utils'
+import {
+  splitSignature,
+  recoverAddress,
+  arrayify,
+  keccak256
+} from 'ethers/utils'
 import SignatureVerifier from './SignatureVerifier'
 import { Bytes } from '../types/Codables'
 
 export const secp256k1Verifier: SignatureVerifier = {
   verify: (message: Bytes, signature: Bytes, publicKey: Bytes) => {
     const sig = splitSignature(signature.toHexString())
-    const addr = recoverAddress(message.toHexString(), sig)
+    const addr = recoverAddress(
+      arrayify(keccak256(arrayify(message.data))),
+      sig
+    )
     return Promise.resolve(
-      addr.toLocaleLowerCase() === publicKey.intoString().toLocaleLowerCase()
+      addr.toLocaleLowerCase() === publicKey.toHexString().toLocaleLowerCase()
     )
   }
 }


### PR DESCRIPTION
### Why

To sign a message, we shoud convert the message to 32 bytes value. So I modified verifier.

### What

* hash message before verifying signature
* public key in this context means hex string of address data(It's different definition of ethereum, so we'll change the name later)
