### PR TITLE
Fix rangedb iterator

### DIFF
--- a/__tests__/db/RangeDb.test.ts
+++ b/__tests__/db/RangeDb.test.ts
@@ -24,6 +24,13 @@ describe('RangeDb', () => {
     const ranges = await rangeDb.get(0n, 300n)
     expect(ranges.length).toEqual(3)
   })
+  it('get mid range', async () => {
+    await rangeDb.put(0n, 10n, alice)
+    await rangeDb.put(10n, 20n, bob)
+    await rangeDb.put(20n, 30n, carol)
+    const ranges = await rangeDb.get(10n, 15n)
+    expect(ranges.length).toEqual(1)
+  })
   it('get small range', async () => {
     await rangeDb.put(120n, 150n, alice)
     await rangeDb.put(0n, 20n, bob)

--- a/src/db/InMemoryKeyValueStore.ts
+++ b/src/db/InMemoryKeyValueStore.ts
@@ -122,7 +122,7 @@ export class InMemoryKeyValueStore implements KeyValueStore {
    * @param bound We can get values greater than `bound` in dictionary order.
    * Please see the document for AbstractIterator's options. https://github.com/snowyu/abstract-iterator#abstractiterator----
    */
-  public iter(bound: Bytes, range?: boolean): MemoryIterator {
+  public iter(bound: Bytes, lowerBoundExclusive?: boolean): MemoryIterator {
     const option: any = {
       gte: this.convertKeyIntoBuffer(bound),
       lt: Buffer.from(this.prefix.increment().data),
@@ -132,7 +132,7 @@ export class InMemoryKeyValueStore implements KeyValueStore {
       keyAsBuffer: true,
       valueAsBuffer: true
     }
-    if (range) {
+    if (lowerBoundExclusive) {
       option.gt = option.gte
       delete option.gte
     }

--- a/src/db/InMemoryKeyValueStore.ts
+++ b/src/db/InMemoryKeyValueStore.ts
@@ -122,19 +122,22 @@ export class InMemoryKeyValueStore implements KeyValueStore {
    * @param bound We can get values greater than `bound` in dictionary order.
    * Please see the document for AbstractIterator's options. https://github.com/snowyu/abstract-iterator#abstractiterator----
    */
-  public iter(bound: Bytes): MemoryIterator {
-    return new MemoryIterator(
-      this.db.iterator({
-        gte: this.convertKeyIntoBuffer(bound),
-        lt: Buffer.from(this.prefix.increment().data),
-        reverse: false,
-        keys: true,
-        values: true,
-        keyAsBuffer: true,
-        valueAsBuffer: true
-      }),
-      this
-    )
+  public iter(bound: Bytes, range?: boolean): MemoryIterator {
+    const option: any = {
+      gte: this.convertKeyIntoBuffer(bound),
+      lt: Buffer.from(this.prefix.increment().data),
+      reverse: false,
+      keys: true,
+      values: true,
+      keyAsBuffer: true,
+      valueAsBuffer: true
+    }
+    if (range) {
+      option.gt = option.gte
+      delete option.gte
+    }
+
+    return new MemoryIterator(this.db.iterator(option), this)
   }
 
   public bucket(key: Bytes): Promise<KeyValueStore> {

--- a/src/db/KeyValueStore.ts
+++ b/src/db/KeyValueStore.ts
@@ -26,7 +26,7 @@ export interface KeyValueStore {
    * `iter` returns `Iterator` which is for seeking values sorted by their keys.
    * @param bound We can get `Iterator` which seek values greater than `lowerBound` in dictionary order.
    */
-  iter(lowerBound: Bytes, range?: boolean): Iterator
+  iter(lowerBound: Bytes, lowerBoundExclusive?: boolean): Iterator
   bucket(key: Bytes): Promise<KeyValueStore>
   close(): Promise<void>
   open(): Promise<void>

--- a/src/db/KeyValueStore.ts
+++ b/src/db/KeyValueStore.ts
@@ -26,7 +26,7 @@ export interface KeyValueStore {
    * `iter` returns `Iterator` which is for seeking values sorted by their keys.
    * @param bound We can get `Iterator` which seek values greater than `lowerBound` in dictionary order.
    */
-  iter(lowerBound: Bytes): Iterator
+  iter(lowerBound: Bytes, range?: boolean): Iterator
   bucket(key: Bytes): Promise<KeyValueStore>
   close(): Promise<void>
   open(): Promise<void>

--- a/src/db/RangeDb.ts
+++ b/src/db/RangeDb.ts
@@ -9,7 +9,7 @@ export class RangeDb implements RangeStore {
   }
 
   public async get(start: bigint, end: bigint): Promise<Range[]> {
-    const iter = await this.kvs.iter(Bytes.fromString(start.toString()))
+    const iter = await this.kvs.iter(Bytes.fromString(start.toString()), true)
     const keyValue = await iter.next()
     if (keyValue === null) {
       return []
@@ -61,7 +61,7 @@ export class RangeDb implements RangeStore {
     const ops: BatchOperation[] = ranges.map(r => {
       return {
         type: 'Del',
-        key: Bytes.fromString(r.end.toString())
+        key: Bytes.fromString(r.end.data.toString())
       }
     })
     await this.kvs.batch(ops)
@@ -72,7 +72,7 @@ export class RangeDb implements RangeStore {
     const ops: BatchOperation[] = ranges.map(r => {
       return {
         type: 'Put',
-        key: Bytes.fromString(r.end.toString()),
+        key: Bytes.fromString(r.end.data.toString()),
         value: r.encode()
       }
     })


### PR DESCRIPTION
RangeDB iterator was broken.
Add test case to reproduce it and fix it by adding `range?` option for KVS `iter` method.