### PR TITLE
Fix replace hint

### DIFF
--- a/packages/db/__tests__/getWitnesses.test.ts
+++ b/packages/db/__tests__/getWitnesses.test.ts
@@ -115,5 +115,13 @@ describe('get witnesses', () => {
         })
       ).toEqual('a,b.0x676767.c,0x646464')
     })
+
+    test('replace vars with dot', async () => {
+      expect(
+        replaceHint('a,b,${a.0}', {
+          'a.0': Bytes.fromString('aaa')
+        })
+      ).toEqual('a,b,0x616161')
+    })
   })
 })

--- a/packages/db/src/getWitnesses.ts
+++ b/packages/db/src/getWitnesses.ts
@@ -82,16 +82,8 @@ export function replaceHint(
   hint: string,
   substitutions: { [key: string]: Bytes }
 ): string {
-  const fillTemplate = function(
-    templateString: string,
-    templateVars: string[]
-  ) {
-    return new Function(
-      ...Object.keys(substitutions).concat(['return `' + templateString + '`'])
-    ).call(null, ...templateVars)
-  }
-  return fillTemplate(
-    hint,
-    Object.keys(substitutions).map(k => substitutions[k].toHexString())
+  return Object.keys(substitutions).reduce(
+    (hint, key) => hint.replace(`\${${key}}`, substitutions[key].toHexString()),
+    hint
   )
 }

--- a/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
+++ b/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
@@ -322,7 +322,7 @@ def test(token, range, block) := Tx(token, range, block).any(tx -> tx())`
         createSubstitutions(['a', 'b'], [a], [])
       }).toThrowError('The length of inputDefs and inputs must be same.')
     })
-    it('return key Bytes map object with propertyInputs', async () => {
+    it('return key Bytes map object with inputDescriptions', async () => {
       const predicateAddress = Address.from(
         '0x0250035000301010002000900380005700060002'
       )

--- a/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
+++ b/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
@@ -312,15 +312,31 @@ def test(token, range, block) := Tx(token, range, block).any(tx -> tx())`
     const a = Bytes.fromString('a')
     const b = Bytes.fromString('b')
     it('return key Bytes map object', async () => {
-      expect(createSubstitutions(['a', 'b'], [a, b], [])).toEqual({
+      expect(
+        createSubstitutions(
+          ['a', 'b'],
+          [a, b],
+          [
+            { name: 'a', children: [] },
+            { name: 'b', children: [] }
+          ]
+        )
+      ).toEqual({
         a,
         b
       })
     })
-    it('throw exception because input length are different', async () => {
+    it('throw exception because of less inputDefs', async () => {
       expect(() => {
-        createSubstitutions(['a', 'b'], [a], [])
-      }).toThrowError('The length of inputDefs and inputs must be same.')
+        createSubstitutions(
+          ['a'],
+          [a],
+          [
+            { name: 'a', children: [] },
+            { name: 'b', children: [] }
+          ]
+        )
+      }).toThrowError('Invalid inputDescriptions b.')
     })
     it('return key Bytes map object with inputDescriptions', async () => {
       const predicateAddress = Address.from(
@@ -333,7 +349,11 @@ def test(token, range, block) := Tx(token, range, block).any(tx -> tx())`
         createSubstitutions(
           ['a', 'b'],
           [nestedProperty, b],
-          [{ name: 'a', children: [0] }]
+          [
+            { name: 'a', children: [] },
+            { name: 'a', children: [0] },
+            { name: 'b', children: [] }
+          ]
         )
       ).toEqual({
         a: nestedProperty,

--- a/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
+++ b/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
@@ -310,15 +310,34 @@ def test(token, range, block) := Tx(token, range, block).any(tx -> tx())`
     const a = Bytes.fromString('a')
     const b = Bytes.fromString('b')
     it('return key Bytes map object', async () => {
-      expect(createSubstitutions(['a', 'b'], [a, b])).toEqual({
+      expect(createSubstitutions(['a', 'b'], [a, b], [])).toEqual({
         a,
         b
       })
     })
     it('throw exception because input length are different', async () => {
       expect(() => {
-        createSubstitutions(['a', 'b'], [a])
+        createSubstitutions(['a', 'b'], [a], [])
       }).toThrowError('The length of inputDefs and inputs must be same.')
+    })
+    it('return key Bytes map object with propertyInputs', async () => {
+      const predicateAddress = Address.from(
+        '0x0250035000301010002000900380005700060002'
+      )
+      const nestedProperty = Coder.encode(
+        new Property(predicateAddress, [a, b]).toStruct()
+      )
+      expect(
+        createSubstitutions(
+          ['a', 'b'],
+          [nestedProperty, b],
+          [{ type: 'NormalInput', inputIndex: 0, children: [0] }]
+        )
+      ).toEqual({
+        a: a,
+        'a.0': a,
+        b
+      })
     })
   })
 })

--- a/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
+++ b/packages/ovm/__tests__/decompiler/CompiledPredicate.test.ts
@@ -5,7 +5,9 @@ import {
   createAtomicPropositionCall,
   constructInput,
   createSubstitutions,
-  CompiledDecider
+  CompiledDecider,
+  parseHintToGetVariables,
+  parseVariable
 } from '../../src'
 import { Address, Bytes, BigNumber } from '@cryptoeconomicslab/primitives'
 import {
@@ -331,13 +333,34 @@ def test(token, range, block) := Tx(token, range, block).any(tx -> tx())`
         createSubstitutions(
           ['a', 'b'],
           [nestedProperty, b],
-          [{ type: 'NormalInput', inputIndex: 0, children: [0] }]
+          [{ name: 'a', children: [0] }]
         )
       ).toEqual({
-        a: a,
+        a: nestedProperty,
         'a.0': a,
         b
       })
+    })
+  })
+
+  describe('parseHintToGetVariables', () => {
+    it('return empty list', async () => {
+      expect(parseHintToGetVariables('a,b,c')).toEqual([])
+    })
+    it('return variable list', async () => {
+      expect(parseHintToGetVariables('${a},b,${c.0}')).toEqual(['a', 'c.0'])
+    })
+  })
+
+  describe('parseVariable', () => {
+    it('do not have children', async () => {
+      expect(parseVariable('a')).toEqual({ name: 'a', children: [] })
+    })
+    it('return variable object', async () => {
+      expect(parseVariable('a.0')).toEqual({ name: 'a', children: [0] })
+    })
+    it('return variable object with children', async () => {
+      expect(parseVariable('a.0.1')).toEqual({ name: 'a', children: [0, 1] })
     })
   })
 })

--- a/packages/ovm/src/decompiler/CompiledPredicate.ts
+++ b/packages/ovm/src/decompiler/CompiledPredicate.ts
@@ -247,24 +247,22 @@ export const createSubstitutions = (
   inputs: Bytes[],
   inputDescriptions: Array<{ name: string; children: number[] }>
 ): { [key: string]: Bytes } => {
-  const result: { [key: string]: Bytes } = {}
-  if (inputDefs.length != inputs.length) {
-    throw new Error('The length of inputDefs and inputs must be same.')
-  }
-  inputDefs.forEach((def, index) => {
-    result[def] = inputs[index]
-  })
-  inputDescriptions
-    .filter(description => description.children.length > 0)
-    .forEach(description => {
+  return inputDescriptions.reduce(
+    (result: { [key: string]: Bytes }, description) => {
       const inputIndex = inputDefs.findIndex(name => name === description.name)
       if (inputIndex < 0) {
-        throw new Error(`invalid propertyInputs ${description.name}.`)
+        throw new Error(`Invalid inputDescriptions ${description.name}.`)
       }
-      const key = description.name + '.' + description.children.join('.')
+      const key =
+        description.name +
+        (description.children.length > 0
+          ? '.' + description.children.join('.')
+          : '')
       result[key] = constructInput(inputs[inputIndex], description.children)
-    })
-  return result
+      return result
+    },
+    {}
+  )
 }
 
 /**

--- a/packages/ovm/src/decompiler/CompiledPredicate.ts
+++ b/packages/ovm/src/decompiler/CompiledPredicate.ts
@@ -240,11 +240,12 @@ const createChildProperty = (
  * create substitution map from key list and value list
  * @param inputDefs key list
  * @param inputs value list
+ * @param inputDescriptions are description data about how inputs are used
  */
 export const createSubstitutions = (
   inputDefs: string[],
   inputs: Bytes[],
-  propertyInputs: Array<{ name: string; children: number[] }>
+  inputDescriptions: Array<{ name: string; children: number[] }>
 ): { [key: string]: Bytes } => {
   const result: { [key: string]: Bytes } = {}
   if (inputDefs.length != inputs.length) {
@@ -253,17 +254,15 @@ export const createSubstitutions = (
   inputDefs.forEach((def, index) => {
     result[def] = inputs[index]
   })
-  propertyInputs
-    .filter(propertyInput => propertyInput.children.length > 0)
-    .forEach(propertyInput => {
-      const inputIndex = inputDefs.findIndex(
-        name => name === propertyInput.name
-      )
+  inputDescriptions
+    .filter(description => description.children.length > 0)
+    .forEach(description => {
+      const inputIndex = inputDefs.findIndex(name => name === description.name)
       if (inputIndex < 0) {
-        throw new Error(`invalid propertyInputs ${propertyInput.name}.`)
+        throw new Error(`invalid propertyInputs ${description.name}.`)
       }
-      const key = propertyInput.name + '.' + propertyInput.children.join('.')
-      result[key] = constructInput(inputs[inputIndex], propertyInput.children)
+      const key = description.name + '.' + description.children.join('.')
+      result[key] = constructInput(inputs[inputIndex], description.children)
     })
   return result
 }

--- a/packages/ovm/src/decompiler/CompiledPredicate.ts
+++ b/packages/ovm/src/decompiler/CompiledPredicate.ts
@@ -117,7 +117,11 @@ export class CompiledPredicate {
         Bytes.fromString(
           replaceHint(
             def.inputs[0] as string,
-            createSubstitutions(def.inputDefs, compiledProperty.inputs)
+            createSubstitutions(
+              def.inputDefs,
+              compiledProperty.inputs,
+              def.propertyInputs
+            )
           )
         ),
         Bytes.fromString(def.inputs[1] as string),
@@ -238,7 +242,8 @@ const createChildProperty = (
  */
 export const createSubstitutions = (
   inputDefs: string[],
-  inputs: Bytes[]
+  inputs: Bytes[],
+  propertyInputs: NormalInput[]
 ): { [key: string]: Bytes } => {
   const result: { [key: string]: Bytes } = {}
   if (inputDefs.length != inputs.length) {
@@ -246,6 +251,14 @@ export const createSubstitutions = (
   }
   inputDefs.forEach((def, index) => {
     result[def] = inputs[index]
+  })
+  propertyInputs.forEach(propertyInput => {
+    const inputDefName = inputDefs[propertyInput.inputIndex]
+    const key = inputDefName + '.' + propertyInput.children.join('.')
+    result[key] = constructInput(
+      inputs[propertyInput.inputIndex],
+      propertyInput.children
+    )
   })
   return result
 }


### PR DESCRIPTION
## Description

fixing createSubstitutions to support variables like "a.0" in hint string.

modifying 2 methods.
* replaceHint
* createSubstitutions

adding 2 methods
* parseHintToGetVariables
* parseVariable