### PR TITLE
 Initialize LightClient in simpler way. Move managers.

### DIFF
--- a/packages/ovm/src/DeciderManager.ts
+++ b/packages/ovm/src/DeciderManager.ts
@@ -3,7 +3,7 @@ import { KeyValueStore } from '@cryptoeconomicslab/db'
 import JsonCoder, { Coder } from '@cryptoeconomicslab/coder'
 import { Decider } from './interfaces/Decider'
 import { Property, Decision, FreeVariable } from './types'
-import { initialize, InitilizationConfig } from './load'
+import { initialize, DeciderConfig } from './load'
 import { CompiledPredicate } from './decompiler'
 import { TraceInfoCreator } from './Tracer'
 
@@ -35,7 +35,7 @@ export class DeciderManager implements DeciderManagerInterface {
    * load JSON file to initialize DeciderManager
    * @param config
    */
-  loadJson(config: InitilizationConfig) {
+  loadJson(config: DeciderConfig) {
     initialize(this, config)
   }
 

--- a/packages/ovm/src/load.ts
+++ b/packages/ovm/src/load.ts
@@ -46,7 +46,7 @@ export interface CompiledPredicateConfig {
   source: TranspilerCompiledPredicate[]
 }
 
-export interface InitilizationConfig {
+export interface DeciderConfig {
   logicalConnectiveAddressTable: {
     [key: string]: string
   }
@@ -59,7 +59,7 @@ export interface InitilizationConfig {
 
 export function initialize(
   deciderManager: DeciderManager,
-  config: InitilizationConfig
+  config: DeciderConfig
 ) {
   initializeDeciders(
     deciderManager,

--- a/packages/plasma-aggregator/__tests__/Aggregator.test.ts
+++ b/packages/plasma-aggregator/__tests__/Aggregator.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@cryptoeconomicslab/plasma'
 import { InMemoryKeyValueStore } from '@cryptoeconomicslab/level-kvs'
 import { RangeStore, RangeDb, KeyValueStore } from '@cryptoeconomicslab/db'
-import { InitilizationConfig, CompiledPredicate } from '@cryptoeconomicslab/ovm'
+import { DeciderConfig, CompiledPredicate } from '@cryptoeconomicslab/ovm'
 import {
   Address,
   Bytes,
@@ -86,7 +86,7 @@ describe('Aggregator integration', () => {
       witnessDb,
       depositContractFactory,
       commitmentContractFactory,
-      config as InitilizationConfig
+      config as DeciderConfig
     )
     aggregator.registerToken(
       Address.from(config.payoutContracts.DepositContract)

--- a/packages/plasma-aggregator/__tests__/StateManager.test.ts
+++ b/packages/plasma-aggregator/__tests__/StateManager.test.ts
@@ -15,7 +15,7 @@ import {
 import {
   DeciderManager,
   CompiledPredicate,
-  InitilizationConfig
+  DeciderConfig
 } from '@cryptoeconomicslab/ovm'
 import JsonCoder from '@cryptoeconomicslab/coder'
 import { EthWallet } from '@cryptoeconomicslab/eth-wallet'
@@ -60,7 +60,7 @@ describe('StateManager', () => {
     const kvs = new InMemoryKeyValueStore(Bytes.fromString('test'))
     const witnessDb = await kvs.bucket(Bytes.fromString('witness'))
     deciderManager = new DeciderManager(witnessDb, JsonCoder)
-    deciderManager.loadJson(config as InitilizationConfig)
+    deciderManager.loadJson(config as DeciderConfig)
     ownershipPredicate = deciderManager.compiledPredicateMap.get(
       'Ownership'
     ) as CompiledPredicate

--- a/packages/plasma-aggregator/src/Aggregator.ts
+++ b/packages/plasma-aggregator/src/Aggregator.ts
@@ -3,7 +3,7 @@ import {
   CompiledPredicate,
   DeciderManager,
   Property,
-  InitilizationConfig
+  DeciderConfig
 } from '@cryptoeconomicslab/ovm'
 import {
   Address,
@@ -55,7 +55,7 @@ export default class Aggregator {
     private witnessDb: KeyValueStore,
     private depositContractFactory: (address: Address) => IDepositContract,
     commitmentContractFactory: (address: Address) => ICommitmentContract,
-    config: InitilizationConfig,
+    config: DeciderConfig,
     private isSubmitter: boolean = false
   ) {
     this.decider = new DeciderManager(witnessDb, ovmContext.coder)

--- a/packages/plasma-light-client/__tests__/LightClient.test.ts
+++ b/packages/plasma-light-client/__tests__/LightClient.test.ts
@@ -81,7 +81,7 @@ import {
 } from '@cryptoeconomicslab/merkle-tree'
 setupContext({ coder: JsonCoder })
 
-async function initialize(): Promise<LightClient> {
+async function initialize(aggregatorEndpoint?: string): Promise<LightClient> {
   const kvs = new IndexedDbKeyValueStore(Bytes.fromString('root'))
   const witnessDb = await kvs.bucket(Bytes.fromString('witness'))
   const wallet = new EthWallet(ethers.Wallet.createRandom())
@@ -112,7 +112,8 @@ async function initialize(): Promise<LightClient> {
     tokenContractFactory,
     commitmentContract,
     ownershipPayoutContract,
-    config: config as InitilizationConfig
+    config: config as InitilizationConfig,
+    aggregatorEndpoint
   })
 }
 
@@ -140,6 +141,12 @@ describe('LightClient', () => {
       expect(client['depositedRangeManager']).toBeInstanceOf(
         DepositedRangeManager
       )
+      expect(client['aggregatorEndpoint']).toEqual('http://localhost:3000')
+    })
+    test('initialize with aggregatorEndpoint', async () => {
+      const aggregatorEndpoint = 'http://test.com'
+      const client = await initialize(aggregatorEndpoint)
+      expect(client['aggregatorEndpoint']).toEqual(aggregatorEndpoint)
     })
   })
 

--- a/packages/plasma-light-client/__tests__/LightClient.test.ts
+++ b/packages/plasma-light-client/__tests__/LightClient.test.ts
@@ -70,8 +70,8 @@ import {
 } from '@cryptoeconomicslab/primitives'
 import { ethers } from 'ethers'
 import { CheckpointManager } from '../src/managers'
-import config from './config.local'
-import { InitilizationConfig, CompiledPredicate } from '@cryptoeconomicslab/ovm'
+import deciderConfig from './config.local'
+import { DeciderConfig, CompiledPredicate } from '@cryptoeconomicslab/ovm'
 import { StateUpdate, Exit } from '@cryptoeconomicslab/plasma'
 import { putWitness } from '@cryptoeconomicslab/db'
 import {
@@ -112,7 +112,7 @@ async function initialize(aggregatorEndpoint?: string): Promise<LightClient> {
     tokenContractFactory,
     commitmentContract,
     ownershipPayoutContract,
-    config: config as InitilizationConfig,
+    deciderConfig: deciderConfig as DeciderConfig,
     aggregatorEndpoint
   })
 }
@@ -182,7 +182,8 @@ describe('LightClient', () => {
     beforeAll(() => {
       su1 = new StateUpdate(
         Address.from(
-          config.deployedPredicateTable.StateUpdatePredicate.deployedAddress
+          deciderConfig.deployedPredicateTable.StateUpdatePredicate
+            .deployedAddress
         ),
         Address.default(),
         new Range(BigNumber.from(0), BigNumber.from(20)),
@@ -191,7 +192,8 @@ describe('LightClient', () => {
       )
       su2 = new StateUpdate(
         Address.from(
-          config.deployedPredicateTable.StateUpdatePredicate.deployedAddress
+          deciderConfig.deployedPredicateTable.StateUpdatePredicate
+            .deployedAddress
         ),
         Address.default(),
         new Range(BigNumber.from(30), BigNumber.from(40)),
@@ -380,7 +382,8 @@ describe('LightClient', () => {
     const owner = client.getOwner(
       new StateUpdate(
         Address.from(
-          config.deployedPredicateTable.StateUpdatePredicate.deployedAddress
+          deciderConfig.deployedPredicateTable.StateUpdatePredicate
+            .deployedAddress
         ),
         Address.default(),
         new Range(BigNumber.from(0), BigNumber.from(20)),

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -59,7 +59,15 @@ enum EmitterEvent {
 }
 
 interface LightClientOptions {
-  aggregatorEndpoint: string
+  wallet: Wallet
+  witnessDb: KeyValueStore
+  adjudicationContract: IAdjudicationContract
+  depositContractFactory: (address: Address) => IDepositContract
+  tokenContractFactory: (address: Address) => IERC20Contract
+  commitmentContract: ICommitmentContract
+  ownershipPayoutContract: IOwnershipPayoutContract
+  config: InitilizationConfig
+  aggregatorEndpoint?: string
 }
 
 export default class LightClient {
@@ -84,9 +92,7 @@ export default class LightClient {
     private checkpointManager: CheckpointManager,
     private depositedRangeManager: DepositedRangeManager,
     config: InitilizationConfig,
-    private options: LightClientOptions = {
-      aggregatorEndpoint: 'http://localhost:3000'
-    }
+    private aggregatorEndpoint: string = 'http://localhost:3000'
   ) {
     this.deciderManager = new DeciderManager(witnessDb, ovmContext.coder)
     this.deciderManager.loadJson(config)
@@ -97,7 +103,36 @@ export default class LightClient {
       throw new Error('Ownership not found')
     }
     this.ownershipPredicate = ownershipPredicate
-    this.apiClient = new APIClient(options.aggregatorEndpoint)
+    this.apiClient = new APIClient(this.aggregatorEndpoint)
+  }
+
+  /**
+   * Initialize Plasma Light Client by options
+   * @param options LightClientOptions to instantiate LightClient
+   */
+  static async initilize(options: LightClientOptions): Promise<LightClient> {
+    const witnessDb = options.witnessDb
+    const stateDb = await witnessDb.bucket(Bytes.fromString('state'))
+    const syncDb = await witnessDb.bucket(Bytes.fromString('sync'))
+    const checkpointDb = await witnessDb.bucket(Bytes.fromString('checkpoint'))
+    const depositedRangeDb = await witnessDb.bucket(
+      Bytes.fromString('depositedRange')
+    )
+    return new LightClient(
+      options.wallet,
+      options.witnessDb,
+      options.adjudicationContract,
+      options.depositContractFactory,
+      options.tokenContractFactory,
+      options.commitmentContract,
+      options.ownershipPayoutContract,
+      new StateManager(stateDb),
+      new SyncManager(syncDb),
+      new CheckpointManager(checkpointDb),
+      new DepositedRangeManager(new RangeDb(depositedRangeDb)),
+      options.config,
+      options.aggregatorEndpoint
+    )
   }
 
   public ownershipProperty(owner: Address): Property {

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -9,7 +9,7 @@ import {
   Property,
   CompiledPredicate,
   DeciderManager,
-  InitilizationConfig
+  DeciderConfig
 } from '@cryptoeconomicslab/ovm'
 import {
   Address,
@@ -66,7 +66,7 @@ interface LightClientOptions {
   tokenContractFactory: (address: Address) => IERC20Contract
   commitmentContract: ICommitmentContract
   ownershipPayoutContract: IOwnershipPayoutContract
-  config: InitilizationConfig
+  deciderConfig: DeciderConfig
   aggregatorEndpoint?: string
 }
 
@@ -91,11 +91,11 @@ export default class LightClient {
     private syncManager: SyncManager,
     private checkpointManager: CheckpointManager,
     private depositedRangeManager: DepositedRangeManager,
-    config: InitilizationConfig,
+    deciderConfig: DeciderConfig,
     private aggregatorEndpoint: string = 'http://localhost:3000'
   ) {
     this.deciderManager = new DeciderManager(witnessDb, ovmContext.coder)
-    this.deciderManager.loadJson(config)
+    this.deciderManager.loadJson(deciderConfig)
     const ownershipPredicate = this.deciderManager.compiledPredicateMap.get(
       'Ownership'
     )
@@ -130,7 +130,7 @@ export default class LightClient {
       new SyncManager(syncDb),
       new CheckpointManager(checkpointDb),
       new DepositedRangeManager(new RangeDb(depositedRangeDb)),
-      options.config,
+      options.deciderConfig,
       options.aggregatorEndpoint
     )
   }


### PR DESCRIPTION
Moving initializing managers such as CheckpointManager or DepositedRangeManager into LightClient in this PR.