### PR TITLE
fix tests

### DIFF
--- a/packages/eth-plasma-light-client/__tests__/index.test.ts
+++ b/packages/eth-plasma-light-client/__tests__/index.test.ts
@@ -1,16 +1,45 @@
 import { ethers } from 'ethers'
 import initialize from '../src/index'
-import { Bytes } from '@cryptoeconomicslab/primitives'
+import { Bytes, Integer } from '@cryptoeconomicslab/primitives'
 import deciderConfig from './config.local'
 import { LevelKeyValueStore } from '@cryptoeconomicslab/level-kvs'
 import {
-  AdjudicationContract,
   CommitmentContract,
+  AdjudicationContract,
   OwnershipPayoutContract
 } from '@cryptoeconomicslab/eth-contract'
 import { setupContext } from '@cryptoeconomicslab/context'
 import JsonCoder from '@cryptoeconomicslab/coder'
 setupContext({ coder: JsonCoder })
+
+// mock
+jest.mock('@cryptoeconomicslab/eth-contract', () => {
+  const {
+    DepositContract,
+    ERC20Contract,
+    CommitmentContract,
+    AdjudicationContract,
+    OwnershipPayoutContract
+  } = jest.requireActual('@cryptoeconomicslab/eth-contract')
+  return {
+    DepositContract,
+    ERC20Contract,
+    CommitmentContract,
+    AdjudicationContract,
+    OwnershipPayoutContract,
+    PETHContract: jest.fn().mockImplementation(() => {
+      return {
+        address: '',
+        approve: jest.fn().mockImplementation(async () => {
+          return
+        }),
+        decimals: jest.fn().mockImplementation(async () => {
+          return Integer.from(18)
+        })
+      }
+    })
+  }
+})
 
 describe('index', () => {
   beforeEach(async () => {})

--- a/packages/eth-plasma-light-client/src/index.ts
+++ b/packages/eth-plasma-light-client/src/index.ts
@@ -61,7 +61,7 @@ export default async function initialize(options: EthLightClientOptions) {
     deciderConfig: options.config,
     aggregatorEndpoint: options.aggregatorEndpoint
   })
-  client.registerCustomToken(
+  await client.registerCustomToken(
     new PETHContract(Address.from(options.config.PlasmaETH), options.wallet),
     depositContractFactory(
       Address.from(options.config.payoutContracts['DepositContract'])

--- a/packages/plasma-light-client/__tests__/SyncManager.test.ts
+++ b/packages/plasma-light-client/__tests__/SyncManager.test.ts
@@ -1,7 +1,7 @@
 import SyncManager from '../src/managers/SyncManager'
 import { KeyValueStore } from '@cryptoeconomicslab/db'
 import { IndexedDbKeyValueStore } from '@cryptoeconomicslab/indexeddb-kvs'
-import { Bytes, BigNumber } from '@cryptoeconomicslab/primitives'
+import { Bytes, BigNumber, FixedBytes } from '@cryptoeconomicslab/primitives'
 import { setupContext } from '@cryptoeconomicslab/context'
 import JsonCoder from '@cryptoeconomicslab/coder'
 import 'fake-indexeddb/auto'
@@ -18,7 +18,10 @@ describe('SyncManager', () => {
   test('get and update', async () => {
     let blockNumber = await syncManager.getLatestSyncedBlockNumber()
     expect(blockNumber).toEqual(BigNumber.from(-1))
-    syncManager.updateSyncedBlockNumber(BigNumber.from(3), Bytes.default())
+    syncManager.updateSyncedBlockNumber(
+      BigNumber.from(3),
+      FixedBytes.default(32)
+    )
     blockNumber = await syncManager.getLatestSyncedBlockNumber()
     expect(blockNumber).toEqual(BigNumber.from(3))
   })


### PR DESCRIPTION
adding await in initialize plasma light client and fixing 2 tests.

```
    Invalid call: Error: contract not deployed (contractAddress="0x13274fe19c0178208bcbee397af8167a7be27f6f", operation="getDeployed", version=4.0.46). This PETHContract doesn't have decimals.
      41 |       return Integer.from(await this.connection.decimals())
      42 |     } catch (e) {
    > 43 |       throw new Error(
         |             ^
      44 |         `Invalid call: ${e}. This PETHContract doesn't have decimals.`
      45 |       )
      46 |     }
      at PETHContract.decimals (packages/eth-contract/src/contract/PETHContract.ts:43:13)
```
