### PR TITLE
Deposit unit should be "wei" in Light Client API

### DIFF
--- a/packages/contract/src/contract/interfaces/IDepositContract.ts
+++ b/packages/contract/src/contract/interfaces/IDepositContract.ts
@@ -1,4 +1,10 @@
-import { Integer, Bytes, Address, Range } from '@cryptoeconomicslab/primitives'
+import {
+  Integer,
+  BigNumber,
+  Bytes,
+  Address,
+  Range
+} from '@cryptoeconomicslab/primitives'
 import { Property } from '@cryptoeconomicslab/ovm'
 
 export interface IDepositContract {
@@ -8,7 +14,7 @@ export interface IDepositContract {
    * @param amount Amount of ETH. Unit is GWEI
    * @param initialState initial state of the range
    */
-  deposit(amount: Integer, initialState: Property): Promise<void>
+  deposit(amount: BigNumber, initialState: Property): Promise<void>
   /**
    * Finalizes checkpoint claim
    * @param checkpoint Checkpoint property which has been decided true by Adjudicator Contract.

--- a/packages/contract/src/contract/interfaces/IDepositContract.ts
+++ b/packages/contract/src/contract/interfaces/IDepositContract.ts
@@ -10,9 +10,9 @@ import { Property } from '@cryptoeconomicslab/ovm'
 export interface IDepositContract {
   address: Address
   /**
-   * Deposits amount of ETH with initial state
-   * @param amount Amount of ETH. Unit is GWEI
-   * @param initialState initial state of the range
+   * Deposits token with initial state
+   * @param amount Amount of token. e.g. The unit is wei in ethereum.
+   * @param initialState Initial state of the range
    */
   deposit(amount: BigNumber, initialState: Property): Promise<void>
   /**

--- a/packages/contract/src/contract/interfaces/IERC20Contract.ts
+++ b/packages/contract/src/contract/interfaces/IERC20Contract.ts
@@ -1,9 +1,9 @@
-import { Address, Integer } from '@cryptoeconomicslab/primitives'
+import { Address, BigNumber } from '@cryptoeconomicslab/primitives'
 
 export interface IERC20Contract {
   address: Address
   /**
    * approve other contract to handle ERC20 balance
    */
-  approve(spender: Address, amount: Integer): Promise<void>
+  approve(spender: Address, amount: BigNumber): Promise<void>
 }

--- a/packages/eth-contract/src/contract/DepositContract.ts
+++ b/packages/eth-contract/src/contract/DepositContract.ts
@@ -43,7 +43,7 @@ export class DepositContract implements IDepositContract {
       contractInterface: this.connection.interface
     })
   }
-  async deposit(amount: Integer, initialState: Property): Promise<void> {
+  async deposit(amount: BigNumber, initialState: Property): Promise<void> {
     return await this.connection.deposit(
       amount.data,
       [initialState.deciderAddress.data, initialState.inputs],

--- a/packages/eth-contract/src/contract/DepositContract.ts
+++ b/packages/eth-contract/src/contract/DepositContract.ts
@@ -43,6 +43,12 @@ export class DepositContract implements IDepositContract {
       contractInterface: this.connection.interface
     })
   }
+
+  /**
+   * Deposits amount of ETH with initial state
+   * @param amount Amount of ETH. The unit is wei.
+   * @param initialState Initial state of the range
+   */
   async deposit(amount: BigNumber, initialState: Property): Promise<void> {
     return await this.connection.deposit(
       amount.data,

--- a/packages/eth-contract/src/contract/ERC20Contract.ts
+++ b/packages/eth-contract/src/contract/ERC20Contract.ts
@@ -1,6 +1,6 @@
 import * as ethers from 'ethers'
 import { IERC20DetailedContract } from '@cryptoeconomicslab/contract'
-import { Address, Integer } from '@cryptoeconomicslab/primitives'
+import { Address, BigNumber, Integer } from '@cryptoeconomicslab/primitives'
 
 export class ERC20Contract implements IERC20DetailedContract {
   public static abi = [
@@ -18,7 +18,7 @@ export class ERC20Contract implements IERC20DetailedContract {
     )
   }
 
-  public async approve(spender: Address, amount: Integer) {
+  public async approve(spender: Address, amount: BigNumber) {
     try {
       await this.connection.approve(spender.data, amount.data)
     } catch (e) {

--- a/packages/eth-contract/src/contract/PETHContract.ts
+++ b/packages/eth-contract/src/contract/PETHContract.ts
@@ -1,6 +1,6 @@
 import * as ethers from 'ethers'
 import { IERC20DetailedContract } from '@cryptoeconomicslab/contract'
-import { Address, Integer } from '@cryptoeconomicslab/primitives'
+import { Address, BigNumber, Integer } from '@cryptoeconomicslab/primitives'
 
 export class PETHContract implements IERC20DetailedContract {
   public static abi = [
@@ -20,7 +20,7 @@ export class PETHContract implements IERC20DetailedContract {
     )
   }
 
-  public async approve(spender: Address, amount: Integer) {
+  public async approve(spender: Address, amount: BigNumber) {
     try {
       await this.connection.wrap(ethers.utils.parseEther(String(amount.data)), {
         value: ethers.utils.parseEther(String(amount.data))

--- a/packages/eth-contract/src/contract/PETHContract.ts
+++ b/packages/eth-contract/src/contract/PETHContract.ts
@@ -20,6 +20,11 @@ export class PETHContract implements IERC20DetailedContract {
     )
   }
 
+  /**
+   * @name approve
+   * @param spender address who is allowed to spend token
+   * @param amount amount of wei.
+   */
   public async approve(spender: Address, amount: BigNumber) {
     const bigNumberifiedAmount = new ethers.utils.BigNumber(
       amount.data.toString()

--- a/packages/eth-contract/src/contract/PETHContract.ts
+++ b/packages/eth-contract/src/contract/PETHContract.ts
@@ -21,13 +21,16 @@ export class PETHContract implements IERC20DetailedContract {
   }
 
   public async approve(spender: Address, amount: BigNumber) {
+    const bigNumberifiedAmount = new ethers.utils.BigNumber(
+      amount.data.toString()
+    )
     try {
-      await this.connection.wrap(ethers.utils.parseEther(String(amount.data)), {
-        value: ethers.utils.parseEther(String(amount.data))
+      await this.connection.wrap(bigNumberifiedAmount, {
+        value: bigNumberifiedAmount
       })
-      await this.connection.approve(spender.data, amount.data)
+      await this.connection.approve(spender.data, bigNumberifiedAmount)
     } catch (e) {
-      await this.connection.unwrap(ethers.utils.parseEther(String(amount.data)))
+      await this.connection.unwrap(bigNumberifiedAmount)
       throw new Error(`Invalid call: ${e}`)
     }
   }

--- a/packages/plasma-light-client/__tests__/LightClient.test.ts
+++ b/packages/plasma-light-client/__tests__/LightClient.test.ts
@@ -238,6 +238,20 @@ describe('LightClient', () => {
       )
     })
 
+    test('deposit with large number as string', async () => {
+      await client.deposit('10000000000000000', defaultAddress)
+
+      expect(mockApprove).toHaveBeenLastCalledWith(
+        Address.default(),
+        BigNumber.fromString('10000000000000000')
+      )
+
+      expect(mockDeposit).toHaveBeenLastCalledWith(
+        BigNumber.fromString('10000000000000000'),
+        client.ownershipProperty(Address.from(client.address))
+      )
+    })
+
     test('deposit calls to unregistered contract should fail', async () => {
       await expect(
         client.deposit(20, Address.from('0x00000000000000000001').data)

--- a/packages/plasma-light-client/__tests__/LightClient.test.ts
+++ b/packages/plasma-light-client/__tests__/LightClient.test.ts
@@ -229,11 +229,11 @@ describe('LightClient', () => {
 
       expect(mockApprove).toHaveBeenLastCalledWith(
         Address.default(),
-        Integer.from(20)
+        BigNumber.from(20)
       )
 
       expect(mockDeposit).toHaveBeenLastCalledWith(
-        Integer.from(20),
+        BigNumber.from(20),
         client.ownershipProperty(Address.from(client.address))
       )
     })

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -190,7 +190,7 @@ export default class LightClient {
   public async getBalance(): Promise<
     Array<{
       depositContractAddress: string
-      amount: number
+      amount: JSBI
       decimals: number
     }>
   > {
@@ -202,7 +202,7 @@ export default class LightClient {
       )
       return {
         depositContractAddress: addr,
-        amount: data.reduce((p, s) => p + Number(s.amount), 0),
+        amount: data.reduce((p, s) => JSBI.add(p, s.amount), JSBI.BigInt(0)),
         decimals: this.tokenManager.getDecimal(Address.from(addr))
       }
     })
@@ -468,7 +468,7 @@ export default class LightClient {
    * @param to to whom transfer
    */
   public async transfer(
-    amount: number,
+    amount: number | string | JSBI,
     depositContractAddressString: string,
     toAddress: string
   ) {
@@ -489,7 +489,7 @@ export default class LightClient {
    * @param stateObject property defining deprecate condition of next state
    */
   public async sendTransaction(
-    amount: number,
+    amount: number | string | JSBI,
     depositContractAddressString: string,
     stateObject: Property
   ) {

--- a/packages/plasma-light-client/src/LightClient.ts
+++ b/packages/plasma-light-client/src/LightClient.ts
@@ -445,7 +445,10 @@ export default class LightClient {
    * @param amount amount to deposit
    * @param depositContractAddress deposit contract address to deposit into
    */
-  public async deposit(amount: number, depositContractAddress: string) {
+  public async deposit(
+    amount: number | string | JSBI,
+    depositContractAddress: string
+  ) {
     const addr = Address.from(depositContractAddress)
     const myAddress = this.wallet.getAddress()
     const depositContract = this.getDepositContract(addr)
@@ -454,9 +457,12 @@ export default class LightClient {
       throw new Error('Contract not found')
     }
 
-    await erc20Contract.approve(depositContract.address, Integer.from(amount))
+    await erc20Contract.approve(
+      depositContract.address,
+      BigNumber.from(JSBI.BigInt(amount))
+    )
     await depositContract.deposit(
-      Integer.from(amount),
+      BigNumber.from(JSBI.BigInt(amount)),
       this.ownershipProperty(myAddress)
     )
   }
@@ -672,7 +678,10 @@ export default class LightClient {
    * @param amount amount to exit
    * @param depositContractAddress deposit contract address to exit
    */
-  public async exit(amount: number, depositContractAddress: string) {
+  public async exit(
+    amount: number | string | JSBI,
+    depositContractAddress: string
+  ) {
     const addr = Address.from(depositContractAddress)
     const stateUpdates = await this.stateManager.resolveStateUpdate(
       addr,

--- a/packages/plasma-light-client/src/managers/StateManager.ts
+++ b/packages/plasma-light-client/src/managers/StateManager.ts
@@ -218,7 +218,7 @@ export default class StateManager {
    */
   public async resolveStateUpdate(
     depositContractAddress: Address,
-    amount: number
+    amount: number | string | JSBI
   ): Promise<StateUpdate[] | null> {
     const db = await this.getRangeDb(Kind.Verified, depositContractAddress)
     const stateUpdates: StateUpdate[] = []


### PR DESCRIPTION
### Why we need this PR.

Now client has inconsistency for deposit. When we call deposit(1), client approve 1 ether but deposit 1 wei.

### Tasks

* deposit unit should be "wei".
* deposit and transfer should support BigNumber
