### PR TITLE
contract wrapper of ethers.js accept string for BigNumber

### DIFF
--- a/packages/eth-contract/src/contract/CommitmentContract.ts
+++ b/packages/eth-contract/src/contract/CommitmentContract.ts
@@ -32,7 +32,7 @@ export class CommitmentContract implements ICommitmentContract {
 
   async submit(blockNumber: BigNumber, root: FixedBytes) {
     return await this.connection.submitRoot(
-      blockNumber.data.toString(),
+      blockNumber.raw,
       root.toHexString(),
       {
         gasLimit: this.gasLimit

--- a/packages/eth-contract/src/contract/DepositContract.ts
+++ b/packages/eth-contract/src/contract/DepositContract.ts
@@ -51,7 +51,7 @@ export class DepositContract implements IDepositContract {
    */
   async deposit(amount: BigNumber, initialState: Property): Promise<void> {
     return await this.connection.deposit(
-      amount.data.toString(),
+      amount.raw,
       [initialState.deciderAddress.data, initialState.inputs],
       {
         gasLimit: this.gasLimit

--- a/packages/eth-contract/src/contract/DepositContract.ts
+++ b/packages/eth-contract/src/contract/DepositContract.ts
@@ -51,7 +51,7 @@ export class DepositContract implements IDepositContract {
    */
   async deposit(amount: BigNumber, initialState: Property): Promise<void> {
     return await this.connection.deposit(
-      amount.data,
+      amount.data.toString(),
       [initialState.deciderAddress.data, initialState.inputs],
       {
         gasLimit: this.gasLimit

--- a/packages/eth-contract/src/contract/ERC20Contract.ts
+++ b/packages/eth-contract/src/contract/ERC20Contract.ts
@@ -20,7 +20,7 @@ export class ERC20Contract implements IERC20DetailedContract {
 
   public async approve(spender: Address, amount: BigNumber) {
     try {
-      await this.connection.approve(spender.data, amount.data.toString())
+      await this.connection.approve(spender.data, amount.raw)
     } catch (e) {
       throw new Error(`Invalid call: ${e}`)
     }

--- a/packages/eth-contract/src/contract/ERC20Contract.ts
+++ b/packages/eth-contract/src/contract/ERC20Contract.ts
@@ -20,7 +20,7 @@ export class ERC20Contract implements IERC20DetailedContract {
 
   public async approve(spender: Address, amount: BigNumber) {
     try {
-      await this.connection.approve(spender.data, amount.data)
+      await this.connection.approve(spender.data, amount.data.toString())
     } catch (e) {
       throw new Error(`Invalid call: ${e}`)
     }

--- a/packages/eth-contract/src/contract/OwnershipPayoutContract.ts
+++ b/packages/eth-contract/src/contract/OwnershipPayoutContract.ts
@@ -28,7 +28,7 @@ export class OwnershipPayoutContract implements IOwnershipPayoutContract {
     await this.connection.finalizeExit(
       depositContractAddress.data,
       [exitProperty.deciderAddress.data, exitProperty.inputs],
-      depositedRangeId.data.toString(),
+      depositedRangeId.raw,
       owner.data,
       {
         gasLimit: this.gasLimit


### PR DESCRIPTION
Converting JSBI to string for fixing error at deposit big amount.
When I deposit big amount, I got an error.

```
Error: invalid input argument (arg="_amount", reason="invalid number value", value=[1569325056,23283064], version=4.0.46)
```