### PR TITLE
clear timeout handler to keep only one event handler run at same time

### DIFF
--- a/packages/eth-contract/src/events/EthEventWatcher.ts
+++ b/packages/eth-contract/src/events/EthEventWatcher.ts
@@ -73,6 +73,8 @@ export default class EventWatcher implements IEventWatcher {
         errorHandler(e)
       }
     }
+    // clear timeout handler to keep only one event handler runs at same time
+    this.cancel()
     this.timer = setTimeout(async () => {
       await this.start(handler, errorHandler)
     }, this.options.interval || DEFAULT_INTERVAL)


### PR DESCRIPTION
keep one handler running even when `start()` method is called without `await` keyword. (Also it's valid in case of that `start()` is called in parallel)
